### PR TITLE
Add IPv6 dual-stack support with configurable bind address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
 # ============================================================
+# Server Binding Configuration
+# ============================================================
+CONTEX_HOST=::                     # Bind address: '::' for dual-stack IPv4+IPv6 (default),
+                                   # '0.0.0.0' for IPv4 only, '::1' or '127.0.0.1' for loopback
+CONTEX_PORT=8001                   # Server port (default: 8001)
+
+# ============================================================
 # PostgreSQL Database Configuration
 # ============================================================
 # PostgreSQL is the primary data store for events, embeddings, and all persistent data

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ USER appuser
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:8001/health || exit 1
+    CMD curl -f http://localhost:8001/health || curl -f -g http://[::1]:8001/health || exit 1
 
 # Expose port
 EXPOSE 8001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       opensearch:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      test: ["CMD-SHELL", "curl -f http://localhost:8001/health || curl -f -g http://[::1]:8001/health"]
       interval: 10s
       timeout: 3s
       retries: 3

--- a/examples/webhook_agent.py
+++ b/examples/webhook_agent.py
@@ -252,7 +252,7 @@ async def main():
     # Note: In production, you'd run this with a proper ASGI server
     config = uvicorn.Config(
         app,
-        host="0.0.0.0",
+        host="::",
         port=WEBHOOK_PORT,
         log_level="info"
     )

--- a/main.py
+++ b/main.py
@@ -418,4 +418,6 @@ except Exception as e:
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8001)
+    host = os.getenv("CONTEX_HOST", "::")
+    port = int(os.getenv("CONTEX_PORT", "8001"))
+    uvicorn.run(app, host=host, port=port)

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -95,8 +95,15 @@ class FeaturesConfig(BaseModel):
     vector_store: str = Field(default="pgvector", description="Vector store backend: 'pgvector' or 'opensearch'")
 
 
+class ServerConfig(BaseModel):
+    """Server binding configuration"""
+    host: str = Field(default="::", description="Bind address (use '::' for dual-stack IPv4+IPv6, '0.0.0.0' for IPv4 only)")
+    port: int = Field(default=8001, ge=1, le=65535, description="Server port")
+
+
 class ContexConfig(BaseModel):
     """Main Contex configuration"""
+    server: ServerConfig = Field(default_factory=ServerConfig)
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     redis: RedisConfig = Field(default_factory=RedisConfig)
     security: SecurityConfig = Field(default_factory=SecurityConfig)
@@ -107,6 +114,10 @@ class ContexConfig(BaseModel):
     def from_env(cls) -> 'ContexConfig':
         """Load configuration from environment variables"""
         return cls(
+            server=ServerConfig(
+                host=os.getenv('CONTEX_HOST', '::'),
+                port=int(os.getenv('CONTEX_PORT', '8001')),
+            ),
             database=DatabaseConfig(
                 url=os.getenv('DATABASE_URL', 'postgresql+asyncpg://contex:contex_password@localhost:5432/contex'),
                 pool_size=int(os.getenv('DATABASE_POOL_SIZE', '5')),


### PR DESCRIPTION
Default bind address changed from 0.0.0.0 (IPv4-only) to :: (dual-stack
IPv4+IPv6). Configurable via CONTEX_HOST and CONTEX_PORT env vars.
Health checks fall back to IPv6 loopback if IPv4 localhost fails.

https://claude.ai/code/session_01FiLFY54y7ienEmnSSHWyro