### PR TITLE
Semantic Subscriptions Plan A: persistent subscriptions + reconcile backend

### DIFF
--- a/alembic/versions/003_add_subscriptions.py
+++ b/alembic/versions/003_add_subscriptions.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
         sa.Column("tenant_id", sa.String(255), nullable=True),
         sa.Column("needs", postgresql.ARRAY(sa.Text()), nullable=False),
         sa.Column("scope", postgresql.JSONB(), nullable=True),
-        sa.Column("bundle", postgresql.JSONB(), nullable=False),
+        sa.Column("bundle", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'")),
         sa.Column("bundle_updated_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),

--- a/alembic/versions/003_add_subscriptions.py
+++ b/alembic/versions/003_add_subscriptions.py
@@ -1,0 +1,39 @@
+"""Add subscriptions table with materialized bundle
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-08-18 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '003'
+down_revision: Union[str, None] = '002'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "subscriptions",
+        sa.Column("subscription_id", sa.String(255), primary_key=True),
+        sa.Column("project_id", sa.String(255), nullable=False),
+        sa.Column("tenant_id", sa.String(255), nullable=True),
+        sa.Column("needs", postgresql.ARRAY(sa.Text()), nullable=False),
+        sa.Column("scope", postgresql.JSONB(), nullable=True),
+        sa.Column("bundle", postgresql.JSONB(), nullable=False),
+        sa.Column("bundle_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("idx_subscriptions_project", "subscriptions", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_subscriptions_project", table_name="subscriptions")
+    op.drop_table("subscriptions")

--- a/src/core/context_engine.py
+++ b/src/core/context_engine.py
@@ -11,6 +11,8 @@ from .database import DatabaseManager
 from .semantic_matcher import SemanticDataMatcher
 from .event_store import EventStore
 from .webhook_dispatcher import WebhookDispatcher
+from src.core.matcher import HybridMatcher
+from src.core.subscriptions import SubscriptionService
 from .models import (
     AgentRegistration,
     DataPublishEvent,
@@ -49,6 +51,9 @@ class ContextEngine:
             db=db,
             similarity_threshold=similarity_threshold,
             max_matches=max_matches
+        )
+        self.subscriptions = SubscriptionService(
+            db, HybridMatcher(self.semantic_matcher), redis
         )
         self.event_store = EventStore(db)
         self.webhook_dispatcher = WebhookDispatcher()
@@ -250,6 +255,9 @@ class ContextEngine:
 
         # 3. Notify agents that depend on this data
         await self._notify_affected_agents(project_id, data_key, data, sequence)
+
+        # Reconcile persistent subscriptions against the new data (inline).
+        await self.subscriptions.reconcile_project(project_id, data_key)
 
         return sequence
 

--- a/src/core/context_engine.py
+++ b/src/core/context_engine.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 import tiktoken
 import toon_format as toon
 from typing import Dict, List, Any, Optional
@@ -11,14 +12,16 @@ from .database import DatabaseManager
 from .semantic_matcher import SemanticDataMatcher
 from .event_store import EventStore
 from .webhook_dispatcher import WebhookDispatcher
-from src.core.matcher import HybridMatcher
-from src.core.subscriptions import SubscriptionService
+from .matcher import HybridMatcher
+from .subscriptions import SubscriptionService
 from .models import (
     AgentRegistration,
     DataPublishEvent,
     RegistrationResponse,
     MatchedDataSource,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ContextEngine:
@@ -257,7 +260,14 @@ class ContextEngine:
         await self._notify_affected_agents(project_id, data_key, data, sequence)
 
         # Reconcile persistent subscriptions against the new data (inline).
-        await self.subscriptions.reconcile_project(project_id, data_key)
+        # A reconcile/matcher failure must not fail the publish (spec §6):
+        # the event is already appended and agents already notified.
+        try:
+            await self.subscriptions.reconcile_project(project_id, data_key)
+        except Exception:
+            logger.exception(
+                "subscription reconcile failed for %s/%s", project_id, data_key
+            )
 
         return sequence
 

--- a/src/core/db_models.py
+++ b/src/core/db_models.py
@@ -419,3 +419,26 @@ class AgentRegistration(Base):
         Index("idx_agent_tenant", "tenant_id"),
         Index("idx_agent_last_seen", "last_seen"),
     )
+
+
+class Subscription(Base):
+    """A persistent semantic subscription: needs + a materialized matched bundle."""
+
+    __tablename__ = "subscriptions"
+
+    subscription_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    project_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    tenant_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    needs: Mapped[List[str]] = mapped_column(ARRAY(Text), nullable=False, default=list)
+    scope: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    # Materialized matches, shape = SemanticDataMatcher.match_agent_needs output.
+    bundle: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict)
+    bundle_updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index("idx_subscriptions_project", "project_id"),
+    )

--- a/src/core/db_models.py
+++ b/src/core/db_models.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     String,
     Text,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, TSVECTOR, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -432,7 +433,7 @@ class Subscription(Base):
     needs: Mapped[List[str]] = mapped_column(ARRAY(Text), nullable=False, default=list)
     scope: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
     # Materialized matches, shape = SemanticDataMatcher.match_agent_needs output.
-    bundle: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict)
+    bundle: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
     bundle_updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/src/core/matcher.py
+++ b/src/core/matcher.py
@@ -1,0 +1,27 @@
+"""The Matcher seam: relevance matching behind a stable interface.
+
+HybridMatcher delegates to SemanticDataMatcher.match_agent_needs, which already
+routes through Plan 1's HybridSearchService (pgvector + Postgres FTS + RRF) when
+hybrid is enabled. `metadata` (item format/type/length) is accepted so a future
+LLM or tiered-model matcher can route on it without changing callers.
+"""
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class Matcher(Protocol):
+    async def match(
+        self, project_id: str, needs: list[str], metadata: dict | None = None
+    ) -> dict[str, list[dict[str, Any]]]:
+        ...
+
+
+class HybridMatcher:
+    def __init__(self, semantic_matcher) -> None:
+        self.semantic_matcher = semantic_matcher
+
+    async def match(
+        self, project_id: str, needs: list[str], metadata: dict | None = None
+    ) -> dict[str, list[dict[str, Any]]]:
+        return await self.semantic_matcher.match_agent_needs(project_id, needs)

--- a/src/core/subscriptions.py
+++ b/src/core/subscriptions.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 from uuid import uuid4
 
 from sqlalchemy import select
 
 from src.core.db_models import Subscription
+
+logger = logging.getLogger(__name__)
 
 
 class SubscriptionService:
@@ -44,6 +47,7 @@ class SubscriptionService:
             row = (await session.execute(
                 select(Subscription).where(Subscription.subscription_id == subscription_id)
             )).scalar_one_or_none()
+            # Idempotent: only commit when a row actually existed; absent id is a no-op.
             if row is not None:
                 await session.delete(row)
                 await session.commit()
@@ -56,23 +60,27 @@ class SubscriptionService:
 
         changed_ids: list[str] = []
         for sub in subs:
-            new_bundle = await self.matcher.match(project_id, sub.needs)  # computed fully first
-            if new_bundle == sub.bundle:
+            try:
+                new_bundle = await self.matcher.match(project_id, sub.needs)  # computed fully first
+                if new_bundle == sub.bundle:
+                    continue
+                now = datetime.now(timezone.utc)  # single timestamp for both DB + event
+                async with self.db.session() as session:  # buffer-until-complete: one atomic swap
+                    row = (await session.execute(
+                        select(Subscription).where(Subscription.subscription_id == sub.subscription_id)
+                    )).scalar_one()
+                    row.bundle = new_bundle
+                    row.bundle_updated_at = now
+                    await session.commit()  # commit BEFORE publish: reader must see committed value
+                await self.redis.publish(
+                    f"subscription:{sub.subscription_id}:updated",
+                    json.dumps({
+                        "subscription_id": sub.subscription_id,
+                        "updated_at": now.isoformat(),
+                    }),
+                )
+                changed_ids.append(sub.subscription_id)
+            except Exception:
+                logger.exception("reconcile failed for subscription %s", sub.subscription_id)
                 continue
-            now = datetime.now(timezone.utc)  # single timestamp for both DB + event
-            async with self.db.session() as session:  # buffer-until-complete: one atomic swap
-                row = (await session.execute(
-                    select(Subscription).where(Subscription.subscription_id == sub.subscription_id)
-                )).scalar_one()
-                row.bundle = new_bundle
-                row.bundle_updated_at = now
-                await session.commit()  # commit BEFORE publish: reader must see committed value
-            await self.redis.publish(
-                f"subscription:{sub.subscription_id}:updated",
-                json.dumps({
-                    "subscription_id": sub.subscription_id,
-                    "updated_at": now.isoformat(),
-                }),
-            )
-            changed_ids.append(sub.subscription_id)
         return changed_ids

--- a/src/core/subscriptions.py
+++ b/src/core/subscriptions.py
@@ -39,6 +39,15 @@ class SubscriptionService:
                 raise KeyError(subscription_id)
             return row.bundle
 
+    async def delete(self, subscription_id) -> None:
+        async with self.db.session() as session:
+            row = (await session.execute(
+                select(Subscription).where(Subscription.subscription_id == subscription_id)
+            )).scalar_one_or_none()
+            if row is not None:
+                await session.delete(row)
+                await session.commit()
+
     async def reconcile_project(self, project_id, changed_data_key=None) -> list[str]:
         async with self.db.session() as session:
             subs = (await session.execute(

--- a/src/core/subscriptions.py
+++ b/src/core/subscriptions.py
@@ -50,18 +50,19 @@ class SubscriptionService:
             new_bundle = await self.matcher.match(project_id, sub.needs)  # computed fully first
             if new_bundle == sub.bundle:
                 continue
+            now = datetime.now(timezone.utc)  # single timestamp for both DB + event
             async with self.db.session() as session:  # buffer-until-complete: one atomic swap
                 row = (await session.execute(
                     select(Subscription).where(Subscription.subscription_id == sub.subscription_id)
                 )).scalar_one()
                 row.bundle = new_bundle
-                row.bundle_updated_at = datetime.now(timezone.utc)
-                await session.commit()
+                row.bundle_updated_at = now
+                await session.commit()  # commit BEFORE publish: reader must see committed value
             await self.redis.publish(
                 f"subscription:{sub.subscription_id}:updated",
                 json.dumps({
                     "subscription_id": sub.subscription_id,
-                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                    "updated_at": now.isoformat(),
                 }),
             )
             changed_ids.append(sub.subscription_id)

--- a/src/core/subscriptions.py
+++ b/src/core/subscriptions.py
@@ -38,3 +38,31 @@ class SubscriptionService:
             if row is None:
                 raise KeyError(subscription_id)
             return row.bundle
+
+    async def reconcile_project(self, project_id, changed_data_key=None) -> list[str]:
+        async with self.db.session() as session:
+            subs = (await session.execute(
+                select(Subscription).where(Subscription.project_id == project_id)
+            )).scalars().all()
+
+        changed_ids: list[str] = []
+        for sub in subs:
+            new_bundle = await self.matcher.match(project_id, sub.needs)  # computed fully first
+            if new_bundle == sub.bundle:
+                continue
+            async with self.db.session() as session:  # buffer-until-complete: one atomic swap
+                row = (await session.execute(
+                    select(Subscription).where(Subscription.subscription_id == sub.subscription_id)
+                )).scalar_one()
+                row.bundle = new_bundle
+                row.bundle_updated_at = datetime.now(timezone.utc)
+                await session.commit()
+            await self.redis.publish(
+                f"subscription:{sub.subscription_id}:updated",
+                json.dumps({
+                    "subscription_id": sub.subscription_id,
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                }),
+            )
+            changed_ids.append(sub.subscription_id)
+        return changed_ids

--- a/src/core/subscriptions.py
+++ b/src/core/subscriptions.py
@@ -1,0 +1,40 @@
+"""Persistent semantic subscriptions with materialized bundles + reconcile."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy import select
+
+from src.core.db_models import Subscription
+
+
+class SubscriptionService:
+    def __init__(self, db, matcher, redis) -> None:
+        self.db = db
+        self.matcher = matcher
+        self.redis = redis
+
+    async def create(
+        self, project_id, needs, tenant_id=None, scope=None, subscription_id=None
+    ) -> str:
+        sub_id = subscription_id or f"sub_{uuid4().hex}"
+        bundle = await self.matcher.match(project_id, needs)
+        async with self.db.session() as session:
+            session.add(Subscription(
+                subscription_id=sub_id, project_id=project_id, tenant_id=tenant_id,
+                needs=list(needs), scope=scope, bundle=bundle,
+                bundle_updated_at=datetime.now(timezone.utc),
+            ))
+            await session.commit()
+        return sub_id
+
+    async def get_bundle(self, subscription_id) -> dict:
+        async with self.db.session() as session:
+            row = (await session.execute(
+                select(Subscription).where(Subscription.subscription_id == subscription_id)
+            )).scalar_one_or_none()
+        if row is None:
+            raise KeyError(subscription_id)
+        return row.bundle

--- a/src/core/subscriptions.py
+++ b/src/core/subscriptions.py
@@ -53,6 +53,15 @@ class SubscriptionService:
                 await session.commit()
 
     async def reconcile_project(self, project_id, changed_data_key=None) -> list[str]:
+        """Bring every subscription in a project back in sync with current data.
+
+        Re-matches each subscription's needs against the project's current data and,
+        for any whose materialized bundle changed, atomically swaps the stored bundle
+        (buffer-until-complete) and emits a `subscription:{id}:updated` event. Returns
+        the list of subscription ids that changed. `changed_data_key` is accepted for a
+        future optimization (reconcile only subscriptions affected by that key); for now
+        every subscription in the project is re-checked.
+        """
         async with self.db.session() as session:
             subs = (await session.execute(
                 select(Subscription).where(Subscription.project_id == project_id)

--- a/src/core/subscriptions.py
+++ b/src/core/subscriptions.py
@@ -35,6 +35,6 @@ class SubscriptionService:
             row = (await session.execute(
                 select(Subscription).where(Subscription.subscription_id == subscription_id)
             )).scalar_one_or_none()
-        if row is None:
-            raise KeyError(subscription_id)
-        return row.bundle
+            if row is None:
+                raise KeyError(subscription_id)
+            return row.bundle

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,7 @@ async def db() -> AsyncGenerator[DatabaseManager, None]:
             try:
                 async with manager.session() as session:
                     # Delete in reverse order of dependencies
+                    await session.execute(text("DELETE FROM subscriptions"))
                     await session.execute(text("DELETE FROM webhook_deliveries"))
                     await session.execute(text("DELETE FROM webhook_endpoints"))
                     await session.execute(text("DELETE FROM audit_events"))

--- a/tests/test_engine_reconcile_integration.py
+++ b/tests/test_engine_reconcile_integration.py
@@ -1,0 +1,24 @@
+# tests/test_engine_reconcile_integration.py
+import pytest
+from src.core.context_engine import ContextEngine
+from src.core.models import DataPublishEvent
+
+
+@pytest.mark.asyncio
+async def test_publish_reconciles_matching_subscription(db, redis):
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+
+    # A subscription whose need should match the doc we publish.
+    sub_id = await engine.subscriptions.create("proj", ["database connection settings"])
+
+    await engine.publish_data(DataPublishEvent(
+        project_id="proj", data_key="db_cfg",
+        data={"host": "localhost", "port": 5432, "purpose": "database connection settings"},
+        data_format="json",
+    ))
+
+    bundle = await engine.subscriptions.get_bundle(sub_id)
+    # the published item now appears in the subscription's materialized bundle
+    all_keys = [m["data_key"] for matches in bundle.values() for m in matches]
+    assert any("db_cfg" in k for k in all_keys)

--- a/tests/test_engine_reconcile_integration.py
+++ b/tests/test_engine_reconcile_integration.py
@@ -22,3 +22,31 @@ async def test_publish_reconciles_matching_subscription(db, redis):
     # the published item now appears in the subscription's materialized bundle
     all_keys = [m["data_key"] for matches in bundle.values() for m in matches]
     assert any("db_cfg" in k for k in all_keys)
+
+
+@pytest.mark.asyncio
+async def test_publish_does_not_affect_other_project(db, redis):
+    """Publishing to projA must not alter subscriptions that belong to projB."""
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+
+    # Create a subscription in projB.
+    sub_b = await engine.subscriptions.create("projB", ["database connection settings"])
+
+    # Capture the bundle immediately after creation (should be empty — no data yet in projB).
+    bundle_before = await engine.subscriptions.get_bundle(sub_b)
+
+    # Publish a matching document to projA — a completely different project.
+    await engine.publish_data(DataPublishEvent(
+        project_id="projA", data_key="projA_db_cfg",
+        data={"host": "projA-host", "port": 5432, "purpose": "database connection settings"},
+        data_format="json",
+    ))
+
+    # projB's subscription bundle must be unchanged: projA's data must not have leaked in.
+    bundle_after = await engine.subscriptions.get_bundle(sub_b)
+    assert bundle_after == bundle_before
+
+    # Sanity-check: no projA data key appears anywhere in projB's bundle.
+    all_keys_b = [m["data_key"] for matches in bundle_after.values() for m in matches]
+    assert not any("projA" in k for k in all_keys_b)

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -18,3 +18,47 @@ async def test_hybrid_matcher_delegates_and_returns_bundle_shape():
     result = await matcher.match("p1", ["auth config"], metadata={"format": "json"})
     assert result == {"auth config": [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}]}
     assert sem.calls == [("p1", ("auth config",))]  # metadata is accepted but not passed through (seam only)
+
+
+@pytest.mark.asyncio
+async def test_matcher_handles_multiple_needs():
+    sem = _FakeSemanticMatcher()
+    matcher = HybridMatcher(sem)
+    result = await matcher.match("p1", ["a", "b"])
+    # delegate called exactly once with both needs
+    assert sem.calls == [("p1", ("a", "b"))]
+    # result has an entry for each need
+    assert set(result.keys()) == {"a", "b"}
+    assert result["a"] == [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}]
+    assert result["b"] == [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}]
+
+
+@pytest.mark.asyncio
+async def test_matcher_empty_needs_returns_empty():
+    sem = _FakeSemanticMatcher()
+    matcher = HybridMatcher(sem)
+    result = await matcher.match("p1", [])
+    # delegate is still called (HybridMatcher is a thin seam; it delegates unconditionally)
+    assert sem.calls == [("p1", ())]
+    # with no needs, the returned dict is empty
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_matcher_passes_through_empty_matches():
+    """Empty match lists are preserved in the returned bundle (not silently dropped)."""
+
+    class _EmptyMatchSemanticMatcher:
+        def __init__(self):
+            self.calls = []
+
+        async def match_agent_needs(self, project_id, needs):
+            self.calls.append((project_id, tuple(needs)))
+            # each need maps to an empty list — no matches found
+            return {n: [] for n in needs}
+
+    sem = _EmptyMatchSemanticMatcher()
+    matcher = HybridMatcher(sem)
+    result = await matcher.match("p1", ["x", "y"])
+    assert result == {"x": [], "y": []}
+    assert sem.calls == [("p1", ("x", "y"))]

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,0 +1,20 @@
+import pytest
+from src.core.matcher import HybridMatcher
+
+
+class _FakeSemanticMatcher:
+    def __init__(self):
+        self.calls = []
+
+    async def match_agent_needs(self, project_id, needs):
+        self.calls.append((project_id, tuple(needs)))
+        return {n: [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}] for n in needs}
+
+
+@pytest.mark.asyncio
+async def test_hybrid_matcher_delegates_and_returns_bundle_shape():
+    sem = _FakeSemanticMatcher()
+    matcher = HybridMatcher(sem)
+    result = await matcher.match("p1", ["auth config"], metadata={"format": "json"})
+    assert result == {"auth config": [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}]}
+    assert sem.calls == [("p1", ("auth config",))]  # metadata is accepted but not passed through (seam only)

--- a/tests/test_subscription_consistency.py
+++ b/tests/test_subscription_consistency.py
@@ -1,0 +1,33 @@
+# tests/test_subscription_consistency.py
+import pytest
+from src.core.context_engine import ContextEngine
+from src.core.models import DataPublishEvent
+
+
+@pytest.mark.asyncio
+async def test_query_matches_subscription_bundle(db, redis):
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    await engine.publish_data(DataPublishEvent(
+        project_id="proj", data_key="db_cfg",
+        data={"purpose": "database connection settings", "port": 5432}, data_format="json",
+    ))
+
+    need = "database connection settings"
+    query_matches = await engine.query_project_data("proj", need, top_k=10, threshold=0.1)
+    sub_id = await engine.subscriptions.create("proj", [need])
+    bundle_matches = (await engine.subscriptions.get_bundle(sub_id))[need]
+
+    # what you test (query) is what you get (subscription): same data_keys, same order
+    assert [m["data_key"] for m in query_matches] == [m["data_key"] for m in bundle_matches]
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_subscription(db, redis):
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    sub_id = await engine.subscriptions.create("proj", ["anything"])
+    await engine.subscriptions.delete(sub_id)
+    with pytest.raises(KeyError):
+        await engine.subscriptions.get_bundle(sub_id)
+    await engine.subscriptions.delete(sub_id)  # idempotent — no error

--- a/tests/test_subscription_consistency.py
+++ b/tests/test_subscription_consistency.py
@@ -18,6 +18,7 @@ async def test_query_matches_subscription_bundle(db, redis):
     sub_id = await engine.subscriptions.create("proj", [need])
     bundle_matches = (await engine.subscriptions.get_bundle(sub_id))[need]
 
+    assert query_matches, "expected non-empty query matches (test would be vacuous otherwise)"
     # what you test (query) is what you get (subscription): same data_keys, same order
     assert [m["data_key"] for m in query_matches] == [m["data_key"] for m in bundle_matches]
 

--- a/tests/test_subscription_model.py
+++ b/tests/test_subscription_model.py
@@ -1,0 +1,22 @@
+import pytest
+from sqlalchemy import select
+from src.core.db_models import Subscription
+
+
+@pytest.mark.asyncio
+async def test_subscription_persists_needs_and_bundle(db):
+    async with db.session() as session:
+        session.add(Subscription(
+            subscription_id="sub_1", project_id="p1",
+            needs=["auth config"], scope=None,
+            bundle={"auth config": [{"data_key": "cfg", "similarity": 0.9, "data": {}, "description": "d"}]},
+        ))
+        await session.commit()
+
+    async with db.session() as session:
+        row = (await session.execute(
+            select(Subscription).where(Subscription.subscription_id == "sub_1")
+        )).scalar_one()
+        assert row.needs == ["auth config"]
+        assert row.bundle["auth config"][0]["data_key"] == "cfg"
+        assert row.project_id == "p1"

--- a/tests/test_subscription_reconcile.py
+++ b/tests/test_subscription_reconcile.py
@@ -42,6 +42,13 @@ async def test_reconcile_no_change_no_emit(db, redis):
     m = _MutableMatcher([{"data_key": "cfg", "similarity": 0.9, "data": {"v": 1}, "description": "d"}])
     svc = SubscriptionService(db, m, redis)
     sub_id = await svc.create("p1", ["auth"])
+
+    pubsub = redis.pubsub()
+    await pubsub.subscribe(f"subscription:{sub_id}:updated")
+
     # matcher returns the same bundle -> no change
     changed = await svc.reconcile_project("p1")
     assert changed == []
+    # no updated event should have been published for the unchanged subscription
+    msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.5)
+    assert msg is None

--- a/tests/test_subscription_reconcile.py
+++ b/tests/test_subscription_reconcile.py
@@ -1,0 +1,47 @@
+# tests/test_subscription_reconcile.py
+import json
+import pytest
+from src.core.subscriptions import SubscriptionService
+
+
+class _MutableMatcher:
+    """Returns whatever bundle it's currently told to."""
+    def __init__(self, bundle):
+        self._bundle = bundle
+
+    async def match(self, project_id, needs, metadata=None):
+        return {n: self._bundle for n in needs}
+
+
+@pytest.mark.asyncio
+async def test_reconcile_updates_changed_bundle_and_emits(db, redis):
+    m = _MutableMatcher([{"data_key": "cfg", "similarity": 0.9, "data": {"v": 1}, "description": "d"}])
+    svc = SubscriptionService(db, m, redis)
+    sub_id = await svc.create("p1", ["auth"])
+
+    pubsub = redis.pubsub()
+    await pubsub.subscribe(f"subscription:{sub_id}:updated")
+
+    # data changes -> matcher now returns a different bundle
+    m._bundle = [{"data_key": "cfg", "similarity": 0.95, "data": {"v": 2}, "description": "d"}]
+    changed = await svc.reconcile_project("p1")
+
+    assert changed == [sub_id]
+    assert (await svc.get_bundle(sub_id))["auth"][0]["data"] == {"v": 2}
+    # an updated event was published for this subscription
+    msg = None
+    for _ in range(5):
+        msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1)
+        if msg:
+            break
+    assert msg is not None and json.loads(msg["data"])["subscription_id"] == sub_id
+
+
+@pytest.mark.asyncio
+async def test_reconcile_no_change_no_emit(db, redis):
+    m = _MutableMatcher([{"data_key": "cfg", "similarity": 0.9, "data": {"v": 1}, "description": "d"}])
+    svc = SubscriptionService(db, m, redis)
+    sub_id = await svc.create("p1", ["auth"])
+    # matcher returns the same bundle -> no change
+    changed = await svc.reconcile_project("p1")
+    assert changed == []

--- a/tests/test_subscription_reconcile.py
+++ b/tests/test_subscription_reconcile.py
@@ -13,6 +13,15 @@ class _MutableMatcher:
         return {n: self._bundle for n in needs}
 
 
+class _KeyedMatcher:
+    """Deterministic matcher: each need has its own independent list of matches."""
+    def __init__(self, bundles):  # bundles: dict[need -> list]
+        self.bundles = bundles
+
+    async def match(self, project_id, needs, metadata=None):
+        return {n: list(self.bundles.get(n, [])) for n in needs}
+
+
 @pytest.mark.asyncio
 async def test_reconcile_updates_changed_bundle_and_emits(db, redis):
     m = _MutableMatcher([{"data_key": "cfg", "similarity": 0.9, "data": {"v": 1}, "description": "d"}])
@@ -52,3 +61,72 @@ async def test_reconcile_no_change_no_emit(db, redis):
     # no updated event should have been published for the unchanged subscription
     msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.5)
     assert msg is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_only_changed_subscription_is_updated(db, redis):
+    """Only the subscription whose bundle changed is returned in changed ids."""
+    initial_a = [{"data_key": "ak", "similarity": 0.7, "data": {"src": "a"}, "description": "da"}]
+    initial_b = [{"data_key": "bk", "similarity": 0.6, "data": {"src": "b"}, "description": "db"}]
+    matcher = _KeyedMatcher({"a": list(initial_a), "b": list(initial_b)})
+    svc = SubscriptionService(db, matcher, redis)
+
+    sub_a = await svc.create("p1", ["a"])
+    sub_b = await svc.create("p1", ["b"])
+
+    # mutate only the "a" need's bundle
+    new_a = [{"data_key": "ak", "similarity": 0.99, "data": {"src": "a-updated"}, "description": "da"}]
+    matcher.bundles["a"] = new_a
+
+    changed = await svc.reconcile_project("p1")
+
+    # only sub_a changed
+    assert sub_a in changed
+    assert sub_b not in changed
+    assert len(changed) == 1
+
+    # sub_a now reflects the new value
+    bundle_a = await svc.get_bundle(sub_a)
+    assert bundle_a["a"][0]["data"] == {"src": "a-updated"}
+
+    # sub_b is untouched
+    bundle_b = await svc.get_bundle(sub_b)
+    assert bundle_b["b"][0]["data"] == {"src": "b"}
+
+
+@pytest.mark.asyncio
+async def test_reconcile_scoped_to_project(db, redis):
+    """reconcile_project("p1") must not touch subscriptions in other projects."""
+    # "other" project matcher always returns a different bundle so that, if reconcile
+    # mistakenly crosses project boundaries, the bundle WOULD change.
+    other_initial = [{"data_key": "ok", "similarity": 0.5, "data": {"v": 0}, "description": None}]
+    other_new = [{"data_key": "ok", "similarity": 0.5, "data": {"v": 999}, "description": None}]
+
+    class _DifferentPerCall:
+        def __init__(self):
+            self._call_count = 0
+            self.bundles = {"need_o": list(other_initial)}
+
+        async def match(self, project_id, needs, metadata=None):
+            self._call_count += 1
+            # Always return a "different" bundle so any cross-project reconcile would be detected
+            return {n: [{"data_key": "ok", "similarity": 0.5, "data": {"v": self._call_count}, "description": None}] for n in needs}
+
+    other_matcher = _DifferentPerCall()
+    svc_other = SubscriptionService(db, other_matcher, redis)
+    sub_other = await svc_other.create("other", ["need_o"])
+
+    # capture the initial bundle stored at creation time
+    bundle_before = await svc_other.get_bundle(sub_other)
+
+    # now reconcile a completely different project using a matcher that returns different data
+    p1_matcher = _KeyedMatcher({"need_p1": [{"data_key": "pk", "similarity": 0.9, "data": {"v": 42}, "description": None}]})
+    svc_p1 = SubscriptionService(db, p1_matcher, redis)
+    changed = await svc_p1.reconcile_project("p1")
+
+    # the "other" project subscription must not appear in changed ids
+    assert sub_other not in changed
+
+    # the "other" subscription's stored bundle must be unchanged
+    bundle_after = await svc_other.get_bundle(sub_other)
+    assert bundle_after == bundle_before

--- a/tests/test_subscription_service.py
+++ b/tests/test_subscription_service.py
@@ -1,6 +1,5 @@
 import pytest
 from src.core.subscriptions import SubscriptionService
-from src.core.db_models import Embedding
 
 
 class _StubMatcher:

--- a/tests/test_subscription_service.py
+++ b/tests/test_subscription_service.py
@@ -1,0 +1,25 @@
+import pytest
+from src.core.subscriptions import SubscriptionService
+from src.core.db_models import Embedding
+
+
+class _StubMatcher:
+    async def match(self, project_id, needs, metadata=None):
+        return {n: [{"data_key": "cfg", "similarity": 0.9, "data": {"x": 1}, "description": "auth"}] for n in needs}
+
+
+@pytest.mark.asyncio
+async def test_create_materializes_bundle_and_get_bundle_reads_it(db, redis):
+    svc = SubscriptionService(db, _StubMatcher(), redis)
+    sub_id = await svc.create("p1", ["auth config"])
+    assert sub_id.startswith("sub_")
+
+    bundle = await svc.get_bundle(sub_id)
+    assert bundle["auth config"][0]["data_key"] == "cfg"
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_unknown_raises(db, redis):
+    svc = SubscriptionService(db, _StubMatcher(), redis)
+    with pytest.raises(KeyError):
+        await svc.get_bundle("nope")


### PR DESCRIPTION
## Semantic Subscriptions — Backend Foundation (Plan A)

First of three increments toward "semantic subscriptions: give your agents context that updates itself." This plan builds the persistence + reconcile foundation that makes a matched context bundle *stored and kept current*. It is additive and backend-only — **no MCP layer, no new REST endpoints** (REST stays frozen); those are Plans B and C.

Design spec: `docs/superpowers/specs/2026-08-18-semantic-subscriptions-design.md` (§4.2 reconcile, §4.3 Matcher seam, §4.4 persistence, §6 error handling)
Plan: `docs/superpowers/plans/2026-08-18-subscriptions-reconcile-backend.md`

### What's in it (12 commits)
- **`Subscription` model + migration 003** — persistent subscriptions with a materialized `bundle` (JSONB, `server_default '{}'`). Closes the "context was push-only, never stored to pull" gap.
- **`Matcher` seam** (`src/core/matcher.py`) — `HybridMatcher` delegates to the existing hybrid search (`match_agent_needs`); the `metadata` param is the seam a future LLM/tiered matcher routes on.
- **`SubscriptionService`** (`src/core/subscriptions.py`) — `create` (persist + materialize), `get_bundle` (the pull), `reconcile_project` (recompute affected bundles), `delete` (idempotent).
- **`reconcile_project`** — buffer-until-complete (compute full bundle → diff-gate → single timestamp → atomic swap → commit **before** Redis emit on `subscription:{id}:updated`), with per-subscription error isolation (§6).
- **Wired into `publish_data`** — reconcile runs inline on publish, guarded so it can't fail the publish (§6). Legacy `_notify_affected_agents` path untouched.
- **Query↔bundle consistency test** — locks "what you test is what you get": `contex_query` and a fresh subscription bundle resolve to the same matches (with a non-empty guard so it can't pass vacuously).

### Deferred (later plans / hardening)
- MCP server layer + `resources/subscribe`→`resources/updated` push (Plan B) — will consume this plan's Redis `subscription:{id}:updated` events.
- Sandbox test/live modes + README GIF (Plan C).
- Async spine, symmetric subscription index, coalescing, load test (the scale engine — future hosted value-add, spec §9).
- Make the query/create paths share an explicit params object so the §4.1 trust property is structural, not incidental (noted for Plan B).

### Tests
374 passed, 18 skipped. The 6 failing `sdk/python` tests are **pre-existing on `main`** (SDK pydantic models out of sync); this branch touches nothing under `sdk/`. Every task went through TDD + a two-stage review; the review loop caught and fixed a test-isolation flaw, a missing DB default, a stored-vs-emitted timestamp mismatch, and a publish-breaking reconcile before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
