### PR TITLE
MCP Server Layer (Plan B): live semantic subscriptions over MCP 2.0

### DIFF
--- a/alembic/versions/004_add_subscription_params.py
+++ b/alembic/versions/004_add_subscription_params.py
@@ -1,0 +1,27 @@
+"""Add top_k and threshold columns to subscriptions
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-08-18 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '004'
+down_revision: Union[str, None] = '003'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('subscriptions', sa.Column('top_k', sa.Integer(), nullable=True))
+    op.add_column('subscriptions', sa.Column('threshold', sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('subscriptions', 'threshold')
+    op.drop_column('subscriptions', 'top_k')

--- a/main.py
+++ b/main.py
@@ -240,21 +240,22 @@ async def lifespan(app: FastAPI):
     # now that app.state.context_engine is set, the handlers will resolve it correctly.
     app.state.mcp_server = _mcp_server
     app.state.mcp_bus = _mcp_bus
-    mcp_stop = asyncio.Event()
-    async with _mcp_server.session_manager.run():
-        bridge_task = asyncio.create_task(run_bridge(redis, _mcp_bus, mcp_stop))
-        try:
-            yield
-        finally:
-            mcp_stop.set()
-            bridge_task.cancel()
+    try:
+        async with _mcp_server.session_manager.run():
+            mcp_stop = asyncio.Event()
+            bridge_task = asyncio.create_task(run_bridge(redis, _mcp_bus, mcp_stop))
             try:
-                await bridge_task
-            except asyncio.CancelledError:
-                pass
-
-    # Shutdown
-    await shutdown_cleanup(app.state)
+                yield
+            finally:
+                mcp_stop.set()
+                bridge_task.cancel()
+                try:
+                    await bridge_task
+                except asyncio.CancelledError:
+                    pass
+    finally:
+        # Shutdown — unconditional even if session_manager teardown raises
+        await shutdown_cleanup(app.state)
 
 
 # Global instances

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 """Contex v0.2.0 - Semantic Context Routing Platform"""
 
+import asyncio
 import os
 from pathlib import Path
 from contextlib import asynccontextmanager
@@ -15,6 +16,8 @@ from sqlalchemy import text
 from src.core.database import init_database
 from src.core.pubsub import create_redis_connection
 from src.core.sentry_integration import init_sentry, flush as sentry_flush
+from src.core.mcp_adapter import build_mcp_server
+from src.core.mcp_bridge import run_bridge
 
 # Environment variables
 REDIS_MODE = os.getenv("REDIS_MODE", "standalone")
@@ -232,7 +235,23 @@ async def lifespan(app: FastAPI):
     app.state.redis = redis
     app.state.health_checker = health_checker
 
-    yield
+    # Wire MCP server: store references and enter the session manager context.
+    # The MCP server and bus were built at module level with a lazy engine accessor;
+    # now that app.state.context_engine is set, the handlers will resolve it correctly.
+    app.state.mcp_server = _mcp_server
+    app.state.mcp_bus = _mcp_bus
+    mcp_stop = asyncio.Event()
+    async with _mcp_server.session_manager.run():
+        bridge_task = asyncio.create_task(run_bridge(redis, _mcp_bus, mcp_stop))
+        try:
+            yield
+        finally:
+            mcp_stop.set()
+            bridge_task.cancel()
+            try:
+                await bridge_task
+            except asyncio.CancelledError:
+                pass
 
     # Shutdown
     await shutdown_cleanup(app.state)
@@ -245,6 +264,14 @@ app = FastAPI(
     version="0.2.0",
     lifespan=lifespan
 )
+
+# Build the MCP server at module level with a lazy engine accessor so the
+# /mcp route exists in app.routes at import time (the test asserts this).
+# The engine is resolved at handler call time via app.state.context_engine,
+# which is populated during lifespan startup before any requests are served.
+_mcp_server, _mcp_bus = build_mcp_server(lambda: app.state.context_engine)
+_mcp_starlette_app = _mcp_server.streamable_http_app(streamable_http_path="/mcp")
+app.mount("/mcp", _mcp_starlette_app)
 
 # CORS Configuration
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*").split(",") if os.getenv("CORS_ORIGINS") else ["*"]

--- a/src/core/db_models.py
+++ b/src/core/db_models.py
@@ -432,6 +432,8 @@ class Subscription(Base):
     tenant_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     needs: Mapped[List[str]] = mapped_column(ARRAY(Text), nullable=False, default=list)
     scope: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    top_k: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    threshold: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     # Materialized matches, shape = SemanticDataMatcher.match_agent_needs output.
     bundle: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict, server_default=text("'{}'"))
     bundle_updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/src/core/matcher.py
+++ b/src/core/matcher.py
@@ -12,7 +12,12 @@ from typing import Any, Protocol
 
 class Matcher(Protocol):
     async def match(
-        self, project_id: str, needs: list[str], metadata: dict | None = None
+        self,
+        project_id: str,
+        needs: list[str],
+        metadata: dict | None = None,
+        top_k: int | None = None,
+        threshold: float | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
         ...
 
@@ -22,6 +27,20 @@ class HybridMatcher:
         self.semantic_matcher = semantic_matcher
 
     async def match(
-        self, project_id: str, needs: list[str], metadata: dict | None = None
+        self,
+        project_id: str,
+        needs: list[str],
+        metadata: dict | None = None,
+        top_k: int | None = None,
+        threshold: float | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
-        return await self.semantic_matcher.match_agent_needs(project_id, needs)
+        sm = self.semantic_matcher
+        old_max, old_thr = sm.max_matches, sm.threshold
+        try:
+            if top_k is not None:
+                sm.max_matches = top_k
+            if threshold is not None:
+                sm.threshold = threshold
+            return await sm.match_agent_needs(project_id, needs)
+        finally:
+            sm.max_matches, sm.threshold = old_max, old_thr

--- a/src/core/matcher.py
+++ b/src/core/matcher.py
@@ -35,6 +35,8 @@ class HybridMatcher:
         threshold: float | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
         sm = self.semantic_matcher
+        if top_k is None and threshold is None:
+            return await sm.match_agent_needs(project_id, needs)
         old_max, old_thr = sm.max_matches, sm.threshold
         try:
             if top_k is not None:

--- a/src/core/mcp_adapter.py
+++ b/src/core/mcp_adapter.py
@@ -7,6 +7,8 @@ import json
 from mcp.server import MCPServer
 from mcp.server.subscriptions import InMemorySubscriptionBus
 
+from src.core.models import DataPublishEvent
+
 
 def build_mcp_server(engine):
     """Build the Contex MCP server bound to a ContextEngine. Returns (server, bus)."""
@@ -35,5 +37,12 @@ def build_mcp_server(engine):
                      mime_type="application/json")
     async def read_subscription(id: str) -> str:
         return json.dumps(await engine.subscriptions.get_bundle(id))
+
+    @server.tool(name="contex_publish", description="Publish/update context data for a project.")
+    async def contex_publish(project_id: str, data_key: str, data: dict, data_format: str = "json") -> str:
+        seq = await engine.publish_data(DataPublishEvent(
+            project_id=project_id, data_key=data_key, data=data, data_format=data_format,
+        ))
+        return json.dumps({"published": data_key, "sequence": str(seq)})
 
     return server, bus

--- a/src/core/mcp_adapter.py
+++ b/src/core/mcp_adapter.py
@@ -18,4 +18,16 @@ def build_mcp_server(engine):
         matches = await engine.query_project_data(project_id, query, top_k=top_k, threshold=threshold)
         return json.dumps({"query": query, "matches": matches})
 
+    @server.tool(name="contex_create_subscription",
+                 description="Create a live subscription; returns its resource URI to subscribe to.")
+    async def contex_create_subscription(project_id: str, needs: list[str],
+                                         top_k: int = 5, threshold: float | None = None) -> str:
+        sub_id = await engine.subscriptions.create(project_id, needs, top_k=top_k, threshold=threshold)
+        return json.dumps({"subscription_id": sub_id, "resource_uri": f"contex://subscriptions/{sub_id}"})
+
+    @server.tool(name="contex_delete_subscription", description="Delete a subscription.")
+    async def contex_delete_subscription(subscription_id: str) -> str:
+        await engine.subscriptions.delete(subscription_id)
+        return json.dumps({"deleted": subscription_id})
+
     return server, bus

--- a/src/core/mcp_adapter.py
+++ b/src/core/mcp_adapter.py
@@ -3,11 +3,11 @@ that imports the mcp SDK. Handlers delegate to ContextEngine/SubscriptionService
 from __future__ import annotations
 
 import json
-from typing import Callable
 
 from mcp.server import MCPServer
 from mcp.server.subscriptions import InMemorySubscriptionBus
 
+from src.core.context_engine import ContextEngine
 from src.core.models import DataPublishEvent
 
 
@@ -25,9 +25,7 @@ def build_mcp_server(engine):
 
     def _get_engine():
         """Resolve the engine, supporting both concrete instances and lazy callables."""
-        if callable(engine) and not hasattr(engine, "query_project_data"):
-            return engine()
-        return engine
+        return engine if isinstance(engine, ContextEngine) else engine()
 
     @server.tool(name="contex_query", description="Semantic query over a project's context (stateless).")
     async def contex_query(project_id: str, query: str, top_k: int = 5, threshold: float | None = None) -> str:

--- a/src/core/mcp_adapter.py
+++ b/src/core/mcp_adapter.py
@@ -20,6 +20,13 @@ def build_mcp_server(engine):
     module-import time).  All tool/resource handlers resolve the engine lazily so
     that either form works correctly at runtime.
     """
+    # InMemorySubscriptionBus is MCP 2.0's in-process fan-out mechanism for
+    # resources/updated notifications to currently-connected MCP client sessions.
+    # It is NOT subscription persistence — durable subscription state (needs +
+    # materialized bundle) lives in the Subscription DB table and survives restarts.
+    # The bus only routes live notifications and is re-established when clients
+    # reconnect. It is multi-replica-safe because the bridge is driven by shared
+    # Redis events.
     bus = InMemorySubscriptionBus()
     server = MCPServer(name="contex", version="0.3.0", subscriptions=bus)
 

--- a/src/core/mcp_adapter.py
+++ b/src/core/mcp_adapter.py
@@ -30,4 +30,10 @@ def build_mcp_server(engine):
         await engine.subscriptions.delete(subscription_id)
         return json.dumps({"deleted": subscription_id})
 
+    @server.resource("contex://subscriptions/{id}", name="subscription",
+                     description="A subscription's current matched context bundle.",
+                     mime_type="application/json")
+    async def read_subscription(id: str) -> str:
+        return json.dumps(await engine.subscriptions.get_bundle(id))
+
     return server, bus

--- a/src/core/mcp_adapter.py
+++ b/src/core/mcp_adapter.py
@@ -3,6 +3,7 @@ that imports the mcp SDK. Handlers delegate to ContextEngine/SubscriptionService
 from __future__ import annotations
 
 import json
+from typing import Callable
 
 from mcp.server import MCPServer
 from mcp.server.subscriptions import InMemorySubscriptionBus
@@ -11,36 +12,54 @@ from src.core.models import DataPublishEvent
 
 
 def build_mcp_server(engine):
-    """Build the Contex MCP server bound to a ContextEngine. Returns (server, bus)."""
+    """Build the Contex MCP server bound to a ContextEngine. Returns (server, bus).
+
+    ``engine`` may be either a ``ContextEngine`` instance (concrete, backward
+    compatible) or a zero-argument callable that returns a ``ContextEngine`` at
+    call time (lazy accessor, used when the engine is not yet available at
+    module-import time).  All tool/resource handlers resolve the engine lazily so
+    that either form works correctly at runtime.
+    """
     bus = InMemorySubscriptionBus()
     server = MCPServer(name="contex", version="0.3.0", subscriptions=bus)
 
+    def _get_engine():
+        """Resolve the engine, supporting both concrete instances and lazy callables."""
+        if callable(engine) and not hasattr(engine, "query_project_data"):
+            return engine()
+        return engine
+
     @server.tool(name="contex_query", description="Semantic query over a project's context (stateless).")
     async def contex_query(project_id: str, query: str, top_k: int = 5, threshold: float | None = None) -> str:
-        matches = await engine.query_project_data(project_id, query, top_k=top_k, threshold=threshold)
+        e = _get_engine()
+        matches = await e.query_project_data(project_id, query, top_k=top_k, threshold=threshold)
         return json.dumps({"query": query, "matches": matches})
 
     @server.tool(name="contex_create_subscription",
                  description="Create a live subscription; returns its resource URI to subscribe to.")
     async def contex_create_subscription(project_id: str, needs: list[str],
                                          top_k: int = 5, threshold: float | None = None) -> str:
-        sub_id = await engine.subscriptions.create(project_id, needs, top_k=top_k, threshold=threshold)
+        e = _get_engine()
+        sub_id = await e.subscriptions.create(project_id, needs, top_k=top_k, threshold=threshold)
         return json.dumps({"subscription_id": sub_id, "resource_uri": f"contex://subscriptions/{sub_id}"})
 
     @server.tool(name="contex_delete_subscription", description="Delete a subscription.")
     async def contex_delete_subscription(subscription_id: str) -> str:
-        await engine.subscriptions.delete(subscription_id)
+        e = _get_engine()
+        await e.subscriptions.delete(subscription_id)
         return json.dumps({"deleted": subscription_id})
 
     @server.resource("contex://subscriptions/{id}", name="subscription",
                      description="A subscription's current matched context bundle.",
                      mime_type="application/json")
     async def read_subscription(id: str) -> str:
-        return json.dumps(await engine.subscriptions.get_bundle(id))
+        e = _get_engine()
+        return json.dumps(await e.subscriptions.get_bundle(id))
 
     @server.tool(name="contex_publish", description="Publish/update context data for a project.")
     async def contex_publish(project_id: str, data_key: str, data: dict, data_format: str = "json") -> str:
-        seq = await engine.publish_data(DataPublishEvent(
+        e = _get_engine()
+        seq = await e.publish_data(DataPublishEvent(
             project_id=project_id, data_key=data_key, data=data, data_format=data_format,
         ))
         return json.dumps({"published": data_key, "sequence": str(seq)})

--- a/src/core/mcp_adapter.py
+++ b/src/core/mcp_adapter.py
@@ -1,0 +1,21 @@
+"""MCP (Model Context Protocol) server for Contex — the ONLY module (with mcp_bridge)
+that imports the mcp SDK. Handlers delegate to ContextEngine/SubscriptionService."""
+from __future__ import annotations
+
+import json
+
+from mcp.server import MCPServer
+from mcp.server.subscriptions import InMemorySubscriptionBus
+
+
+def build_mcp_server(engine):
+    """Build the Contex MCP server bound to a ContextEngine. Returns (server, bus)."""
+    bus = InMemorySubscriptionBus()
+    server = MCPServer(name="contex", version="0.3.0", subscriptions=bus)
+
+    @server.tool(name="contex_query", description="Semantic query over a project's context (stateless).")
+    async def contex_query(project_id: str, query: str, top_k: int = 5, threshold: float | None = None) -> str:
+        matches = await engine.query_project_data(project_id, query, top_k=top_k, threshold=threshold)
+        return json.dumps({"query": query, "matches": matches})
+
+    return server, bus

--- a/src/core/mcp_bridge.py
+++ b/src/core/mcp_bridge.py
@@ -21,7 +21,7 @@ async def handle_message(bus, raw) -> str | None:
     try:
         data = json.loads(raw.decode() if isinstance(raw, (bytes, bytearray)) else raw)
         sub_id = data["subscription_id"]
-    except (ValueError, KeyError, AttributeError):
+    except (ValueError, KeyError, AttributeError, TypeError):
         return None
     uri = resource_uri_for(sub_id)
     await bus.publish(ResourceUpdated(uri=uri))
@@ -35,7 +35,10 @@ async def run_bridge(redis, bus, stop_event: asyncio.Event) -> None:
     try:
         while not stop_event.is_set():
             msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
-            if msg and msg.get("type") in ("pmessage", "message"):
-                await handle_message(bus, msg["data"])
+            try:
+                if msg and msg.get("type") in ("pmessage", "message"):
+                    await handle_message(bus, msg["data"])
+            except Exception:
+                logger.exception("MCP bridge loop error; continuing")
     finally:
         await pubsub.close()

--- a/src/core/mcp_bridge.py
+++ b/src/core/mcp_bridge.py
@@ -1,0 +1,41 @@
+"""Bridges Plan A's Redis `subscription:{id}:updated` events into MCP resources/updated
+notifications. The second of two modules allowed to import the mcp SDK."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from mcp.server.subscriptions import ResourceUpdated
+
+logger = logging.getLogger(__name__)
+
+_CHANNEL_PATTERN = "subscription:*:updated"
+
+
+def resource_uri_for(subscription_id: str) -> str:
+    return f"contex://subscriptions/{subscription_id}"
+
+
+async def handle_message(bus, raw) -> str | None:
+    try:
+        data = json.loads(raw.decode() if isinstance(raw, (bytes, bytearray)) else raw)
+        sub_id = data["subscription_id"]
+    except (ValueError, KeyError, AttributeError):
+        return None
+    uri = resource_uri_for(sub_id)
+    await bus.publish(ResourceUpdated(uri=uri))
+    return uri
+
+
+async def run_bridge(redis, bus, stop_event: asyncio.Event) -> None:
+    pubsub = redis.pubsub()
+    await pubsub.psubscribe(_CHANNEL_PATTERN)
+    logger.info("MCP bridge listening on %s", _CHANNEL_PATTERN)
+    try:
+        while not stop_event.is_set():
+            msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+            if msg and msg.get("type") in ("pmessage", "message"):
+                await handle_message(bus, msg["data"])
+    finally:
+        await pubsub.close()

--- a/src/core/mcp_bridge.py
+++ b/src/core/mcp_bridge.py
@@ -11,17 +11,19 @@ from mcp.server.subscriptions import ResourceUpdated
 logger = logging.getLogger(__name__)
 
 _CHANNEL_PATTERN = "subscription:*:updated"
+_RESOURCE_URI_PREFIX = "contex://subscriptions/"
 
 
 def resource_uri_for(subscription_id: str) -> str:
-    return f"contex://subscriptions/{subscription_id}"
+    return f"{_RESOURCE_URI_PREFIX}{subscription_id}"
 
 
 async def handle_message(bus, raw) -> str | None:
     try:
         data = json.loads(raw.decode() if isinstance(raw, (bytes, bytearray)) else raw)
         sub_id = data["subscription_id"]
-    except (ValueError, KeyError, AttributeError, TypeError):
+    except (ValueError, KeyError, AttributeError, TypeError) as exc:
+        logger.warning("MCP bridge dropped a malformed subscription-updated message: %s", exc)
         return None
     uri = resource_uri_for(sub_id)
     await bus.publish(ResourceUpdated(uri=uri))
@@ -41,4 +43,4 @@ async def run_bridge(redis, bus, stop_event: asyncio.Event) -> None:
             except Exception:
                 logger.exception("MCP bridge loop error; continuing")
     finally:
-        await pubsub.close()
+        await pubsub.aclose()

--- a/src/core/subscriptions.py
+++ b/src/core/subscriptions.py
@@ -27,7 +27,7 @@ class SubscriptionService:
         async with self.db.session() as session:
             session.add(Subscription(
                 subscription_id=sub_id, project_id=project_id, tenant_id=tenant_id,
-                needs=list(needs), scope=scope, bundle=bundle,
+                needs=list(needs), scope=scope, top_k=top_k, threshold=threshold, bundle=bundle,
                 bundle_updated_at=datetime.now(timezone.utc),
             ))
             await session.commit()
@@ -70,7 +70,7 @@ class SubscriptionService:
         changed_ids: list[str] = []
         for sub in subs:
             try:
-                new_bundle = await self.matcher.match(project_id, sub.needs)  # computed fully first
+                new_bundle = await self.matcher.match(project_id, sub.needs, top_k=sub.top_k, threshold=sub.threshold)  # computed fully first
                 if new_bundle == sub.bundle:
                     continue
                 now = datetime.now(timezone.utc)  # single timestamp for both DB + event

--- a/src/core/subscriptions.py
+++ b/src/core/subscriptions.py
@@ -20,10 +20,10 @@ class SubscriptionService:
         self.redis = redis
 
     async def create(
-        self, project_id, needs, tenant_id=None, scope=None, subscription_id=None
+        self, project_id, needs, tenant_id=None, scope=None, subscription_id=None, top_k=None, threshold=None
     ) -> str:
         sub_id = subscription_id or f"sub_{uuid4().hex}"
-        bundle = await self.matcher.match(project_id, needs)
+        bundle = await self.matcher.match(project_id, needs, top_k=top_k, threshold=threshold)
         async with self.db.session() as session:
             session.add(Subscription(
                 subscription_id=sub_id, project_id=project_id, tenant_id=tenant_id,

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -5,6 +5,8 @@ from src.core.matcher import HybridMatcher
 class _FakeSemanticMatcher:
     def __init__(self):
         self.calls = []
+        self.max_matches = 10
+        self.threshold = 0.35
 
     async def match_agent_needs(self, project_id, needs):
         self.calls.append((project_id, tuple(needs)))
@@ -51,6 +53,8 @@ async def test_matcher_passes_through_empty_matches():
     class _EmptyMatchSemanticMatcher:
         def __init__(self):
             self.calls = []
+            self.max_matches = 10
+            self.threshold = 0.35
 
         async def match_agent_needs(self, project_id, needs):
             self.calls.append((project_id, tuple(needs)))

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -5,8 +5,6 @@ from src.core.matcher import HybridMatcher
 class _FakeSemanticMatcher:
     def __init__(self):
         self.calls = []
-        self.max_matches = 10
-        self.threshold = 0.35
 
     async def match_agent_needs(self, project_id, needs):
         self.calls.append((project_id, tuple(needs)))
@@ -53,8 +51,6 @@ async def test_matcher_passes_through_empty_matches():
     class _EmptyMatchSemanticMatcher:
         def __init__(self):
             self.calls = []
-            self.max_matches = 10
-            self.threshold = 0.35
 
         async def match_agent_needs(self, project_id, needs):
             self.calls.append((project_id, tuple(needs)))

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -21,3 +21,20 @@ async def test_contex_query_tool_returns_matches(db, redis):
     payload = json.loads(text)
     # Engine decomposes JSON objects into nodes; "db" data_key becomes "db.root" (or "db.<path>")
     assert any(m["data_key"].startswith("db") for m in payload["matches"])
+
+
+@pytest.mark.asyncio
+async def test_query_no_matches_returns_empty(db, redis):
+    """A query against a project with no data (or no matches above threshold)
+    must return an empty matches list."""
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.99, max_matches=10)
+    await engine.initialize()
+    server, _ = build_mcp_server(engine)
+
+    result = await server.call_tool("contex_query", {
+        # Use an isolated project so no data exists, and a very high threshold
+        # so even if stray data were present it would not match.
+        "project_id": "empty_project_xyz", "query": "this query matches nothing", "top_k": 10, "threshold": 0.99,
+    })
+    payload = json.loads(result.content[0].text)
+    assert payload["matches"] == []

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,0 +1,23 @@
+import json
+import pytest
+from src.core.context_engine import ContextEngine
+from src.core.models import DataPublishEvent
+from src.core.mcp_adapter import build_mcp_server
+
+
+@pytest.mark.asyncio
+async def test_contex_query_tool_returns_matches(db, redis):
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    await engine.publish_data(DataPublishEvent(
+        project_id="p", data_key="db", data={"purpose": "database connection settings"}, data_format="json",
+    ))
+    server, bus = build_mcp_server(engine)
+    result = await server.call_tool("contex_query", {
+        "project_id": "p", "query": "database connection settings", "top_k": 10, "threshold": 0.1,
+    })
+    # call_tool returns a CallToolResult; its content carries the JSON payload text
+    text = result.content[0].text
+    payload = json.loads(text)
+    # Engine decomposes JSON objects into nodes; "db" data_key becomes "db.root" (or "db.<path>")
+    assert any(m["data_key"].startswith("db") for m in payload["matches"])

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -1,0 +1,24 @@
+import json
+import pytest
+from mcp.server.subscriptions import InMemorySubscriptionBus, ResourceUpdated
+from src.core.mcp_bridge import handle_message, resource_uri_for
+
+
+@pytest.mark.asyncio
+async def test_handle_message_publishes_resource_updated():
+    bus = InMemorySubscriptionBus()
+    seen = []
+    bus.subscribe(lambda ev: seen.append(ev))
+    payload = json.dumps({"subscription_id": "sub_abc", "updated_at": "2026-08-18T00:00:00Z"})
+
+    uri = await handle_message(bus, payload)
+
+    assert uri == "contex://subscriptions/sub_abc"
+    assert resource_uri_for("sub_abc") == uri
+    assert any(isinstance(ev, ResourceUpdated) and ev.uri == uri for ev in seen)
+
+
+@pytest.mark.asyncio
+async def test_handle_message_ignores_garbage():
+    bus = InMemorySubscriptionBus()
+    assert await handle_message(bus, b"not json") is None

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -21,4 +21,7 @@ async def test_handle_message_publishes_resource_updated():
 @pytest.mark.asyncio
 async def test_handle_message_ignores_garbage():
     bus = InMemorySubscriptionBus()
+    seen = []
+    bus.subscribe(lambda ev: seen.append(ev))
     assert await handle_message(bus, b"not json") is None
+    assert seen == []

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -1,7 +1,9 @@
+import asyncio
 import json
+import logging
 import pytest
 from mcp.server.subscriptions import InMemorySubscriptionBus, ResourceUpdated
-from src.core.mcp_bridge import handle_message, resource_uri_for
+from src.core.mcp_bridge import handle_message, resource_uri_for, run_bridge
 
 
 @pytest.mark.asyncio
@@ -25,3 +27,49 @@ async def test_handle_message_ignores_garbage():
     bus.subscribe(lambda ev: seen.append(ev))
     assert await handle_message(bus, b"not json") is None
     assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_run_bridge_pushes_on_real_redis_event(redis):
+    """End-to-end: run_bridge psubscribes, receives a Redis publish, and fans
+    out a ResourceUpdated to the bus — exercising the full loop."""
+    bus = InMemorySubscriptionBus()
+    seen = []
+    bus.subscribe(lambda ev: seen.append(ev))
+
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(run_bridge(redis, bus, stop_event))
+
+    # Give the bridge a moment to psubscribe before publishing.
+    await asyncio.sleep(0.1)
+
+    payload = json.dumps({"subscription_id": "sub_x", "updated_at": "2026-08-18T00:00:00Z"})
+    await redis.publish("subscription:sub_x:updated", payload.encode())
+
+    # Poll (up to ~2s) until a ResourceUpdated with the expected URI appears.
+    expected_uri = "contex://subscriptions/sub_x"
+    deadline = asyncio.get_event_loop().time() + 2.0
+    while asyncio.get_event_loop().time() < deadline:
+        if any(isinstance(ev, ResourceUpdated) and ev.uri == expected_uri for ev in seen):
+            break
+        await asyncio.sleep(0.05)
+
+    stop_event.set()
+    try:
+        await asyncio.wait_for(task, timeout=2.0)
+    except asyncio.TimeoutError:
+        task.cancel()
+
+    assert any(isinstance(ev, ResourceUpdated) and ev.uri == expected_uri for ev in seen), (
+        f"Expected ResourceUpdated(uri={expected_uri!r}) but saw: {seen}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_message_logs_on_garbage(caplog):
+    """Malformed messages must return None AND emit a WARNING (Fix A)."""
+    bus = InMemorySubscriptionBus()
+    with caplog.at_level(logging.WARNING):
+        result = await handle_message(bus, b"not json")
+    assert result is None
+    assert "malformed" in caplog.text.lower()

--- a/tests/test_mcp_live_update_e2e.py
+++ b/tests/test_mcp_live_update_e2e.py
@@ -32,8 +32,8 @@ async def test_publish_pushes_resource_updated_and_bundle_refreshes(db, redis):
 
     # drain the redis event and drive the bridge (stands in for the running bridge task)
     msg = None
-    for _ in range(5):
-        msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1)
+    for _ in range(10):
+        msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=2)
         if msg:
             break
     assert msg is not None, "reconcile did not emit a subscription-updated event"
@@ -52,3 +52,6 @@ async def test_publish_pushes_resource_updated_and_bundle_refreshes(db, redis):
         for matches in bundle.values()
         for m in matches
     )
+
+    await pubsub.unsubscribe(f"subscription:{sub_id}:updated")
+    await pubsub.close()

--- a/tests/test_mcp_live_update_e2e.py
+++ b/tests/test_mcp_live_update_e2e.py
@@ -1,0 +1,54 @@
+# tests/test_mcp_live_update_e2e.py
+import json
+import pytest
+from mcp.server.subscriptions import ResourceUpdated
+from src.core.context_engine import ContextEngine
+from src.core.models import DataPublishEvent
+from src.core.mcp_adapter import build_mcp_server
+from src.core.mcp_bridge import handle_message, resource_uri_for
+
+
+@pytest.mark.asyncio
+async def test_publish_pushes_resource_updated_and_bundle_refreshes(db, redis):
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    server, bus = build_mcp_server(engine)
+
+    sub_id = await engine.subscriptions.create("p", ["database connection settings"], top_k=10, threshold=0.1)
+    uri = resource_uri_for(sub_id)
+
+    updated = []
+    bus.subscribe(lambda ev: updated.append(ev))
+
+    # subscribe to the raw Redis channel to capture the reconcile emit
+    pubsub = redis.pubsub()
+    await pubsub.subscribe(f"subscription:{sub_id}:updated")
+
+    # publish matching data -> reconcile updates the bundle + emits the redis event
+    await engine.publish_data(DataPublishEvent(
+        project_id="p", data_key="db",
+        data={"purpose": "database connection settings"}, data_format="json",
+    ))
+
+    # drain the redis event and drive the bridge (stands in for the running bridge task)
+    msg = None
+    for _ in range(5):
+        msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1)
+        if msg:
+            break
+    assert msg is not None, "reconcile did not emit a subscription-updated event"
+    pushed_uri = await handle_message(bus, msg["data"])
+
+    # the MCP resources/updated push fired for our subscription's URI
+    assert pushed_uri == uri
+    assert any(isinstance(ev, ResourceUpdated) and ev.uri == uri for ev in updated)
+
+    # re-reading the resource shows the freshly-materialized bundle containing the new item
+    contents = list(await server.read_resource(uri))
+    bundle = json.loads(contents[0].content)
+    # Engine decomposes structured JSON into path-suffixed node keys ("db" -> "db.root"/"db.purpose"...)
+    assert any(
+        m["data_key"].startswith("db.") or m["data_key"] == "db"
+        for matches in bundle.values()
+        for m in matches
+    )

--- a/tests/test_mcp_live_update_e2e.py
+++ b/tests/test_mcp_live_update_e2e.py
@@ -54,4 +54,4 @@ async def test_publish_pushes_resource_updated_and_bundle_refreshes(db, redis):
     )
 
     await pubsub.unsubscribe(f"subscription:{sub_id}:updated")
-    await pubsub.close()
+    await pubsub.aclose()

--- a/tests/test_mcp_mount.py
+++ b/tests/test_mcp_mount.py
@@ -1,0 +1,13 @@
+import main
+
+
+def test_mcp_mounted_at_slash_mcp():
+    paths = [getattr(r, "path", "") for r in main.app.routes]
+    assert any(p == "/mcp" or p.startswith("/mcp") for p in paths), f"/mcp not mounted; routes={paths}"
+
+
+def test_build_mcp_server_is_wired_in_main():
+    # the factory + bridge are imported and used by main
+    import inspect
+    src = inspect.getsource(main)
+    assert "build_mcp_server" in src and "run_bridge" in src and "session_manager" in src

--- a/tests/test_mcp_publish_tool.py
+++ b/tests/test_mcp_publish_tool.py
@@ -1,0 +1,21 @@
+import json
+import pytest
+from src.core.context_engine import ContextEngine
+from src.core.mcp_adapter import build_mcp_server
+
+
+@pytest.mark.asyncio
+async def test_publish_tool_updates_subscription_bundle(db, redis):
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    server, _ = build_mcp_server(engine)
+    sub_id = await engine.subscriptions.create("p", ["database connection settings"], top_k=10, threshold=0.1)
+
+    res = json.loads((await server.call_tool("contex_publish", {
+        "project_id": "p", "data_key": "db",
+        "data": {"purpose": "database connection settings"}, "data_format": "json",
+    })).content[0].text)
+    assert res["published"] == "db"
+
+    bundle = await engine.subscriptions.get_bundle(sub_id)
+    assert any(m["data_key"].startswith("db.") or m["data_key"] == "db" for matches in bundle.values() for m in matches)

--- a/tests/test_mcp_resource.py
+++ b/tests/test_mcp_resource.py
@@ -1,0 +1,18 @@
+import json
+import pytest
+from src.core.context_engine import ContextEngine
+from src.core.mcp_adapter import build_mcp_server
+
+
+@pytest.mark.asyncio
+async def test_read_subscription_resource_returns_bundle(db, redis):
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    server, _ = build_mcp_server(engine)
+    sub_id = await engine.subscriptions.create("p", ["auth config"], top_k=10, threshold=0.1)
+
+    contents = await server.read_resource(f"contex://subscriptions/{sub_id}")
+    # read_resource returns an iterable of ReadResourceContents; take the first's text
+    first = list(contents)[0]
+    bundle = json.loads(first.content)
+    assert "auth config" in bundle

--- a/tests/test_mcp_resource.py
+++ b/tests/test_mcp_resource.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from mcp.server.mcpserver.exceptions import ResourceError
 from src.core.context_engine import ContextEngine
 from src.core.mcp_adapter import build_mcp_server
 
@@ -16,3 +17,15 @@ async def test_read_subscription_resource_returns_bundle(db, redis):
     first = list(contents)[0]
     bundle = json.loads(first.content)
     assert "auth config" in bundle
+
+
+@pytest.mark.asyncio
+async def test_read_unknown_subscription_raises(db, redis):
+    """Reading a non-existent subscription resource must raise ResourceError
+    (mcp wraps the KeyError from get_bundle into ResourceError)."""
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    server, _ = build_mcp_server(engine)
+
+    with pytest.raises(ResourceError):
+        await server.read_resource("contex://subscriptions/does_not_exist")

--- a/tests/test_mcp_subscription_tools.py
+++ b/tests/test_mcp_subscription_tools.py
@@ -1,0 +1,26 @@
+import json
+import pytest
+from src.core.context_engine import ContextEngine
+from src.core.mcp_adapter import build_mcp_server
+
+
+@pytest.mark.asyncio
+async def test_create_and_delete_subscription_tools(db, redis):
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    server, _ = build_mcp_server(engine)
+
+    created = json.loads((await server.call_tool("contex_create_subscription", {
+        "project_id": "p", "needs": ["auth config"], "top_k": 10, "threshold": 0.1,
+    })).content[0].text)
+    sub_id = created["subscription_id"]
+    assert created["resource_uri"] == f"contex://subscriptions/{sub_id}"
+    # bundle now exists
+    assert await engine.subscriptions.get_bundle(sub_id) is not None
+
+    deleted = json.loads((await server.call_tool("contex_delete_subscription", {
+        "subscription_id": sub_id,
+    })).content[0].text)
+    assert deleted["deleted"] == sub_id
+    with pytest.raises(KeyError):
+        await engine.subscriptions.get_bundle(sub_id)

--- a/tests/test_mcp_subscription_tools.py
+++ b/tests/test_mcp_subscription_tools.py
@@ -24,3 +24,36 @@ async def test_create_and_delete_subscription_tools(db, redis):
     assert deleted["deleted"] == sub_id
     with pytest.raises(KeyError):
         await engine.subscriptions.get_bundle(sub_id)
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_is_idempotent(db, redis):
+    """Deleting a subscription that doesn't exist must succeed with no error
+    and return {"deleted": <id>} (idempotent delete)."""
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    server, _ = build_mcp_server(engine)
+
+    result = await server.call_tool("contex_delete_subscription", {"subscription_id": "sub_nope"})
+    payload = json.loads(result.content[0].text)
+    assert payload == {"deleted": "sub_nope"}
+
+
+@pytest.mark.asyncio
+async def test_create_with_empty_needs(db, redis):
+    """Creating a subscription with no needs should succeed and produce an empty bundle."""
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    server, _ = build_mcp_server(engine)
+
+    result = await server.call_tool("contex_create_subscription", {
+        "project_id": "p", "needs": [], "top_k": 10, "threshold": 0.1,
+    })
+    payload = json.loads(result.content[0].text)
+    sub_id = payload["subscription_id"]
+    assert "subscription_id" in payload
+    assert payload["resource_uri"] == f"contex://subscriptions/{sub_id}"
+
+    bundle = await engine.subscriptions.get_bundle(sub_id)
+    # No needs → empty bundle (nothing to match)
+    assert bundle == {}

--- a/tests/test_subscription_params.py
+++ b/tests/test_subscription_params.py
@@ -1,0 +1,21 @@
+import pytest
+from src.core.context_engine import ContextEngine
+from src.core.models import DataPublishEvent
+
+
+@pytest.mark.asyncio
+async def test_create_with_params_matches_query_with_same_params(db, redis):
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.9, max_matches=1)
+    await engine.initialize()
+    await engine.publish_data(DataPublishEvent(
+        project_id="p", data_key="db", data={"purpose": "database connection settings"}, data_format="json",
+    ))
+    need = "database connection settings"
+    # query with explicit permissive params
+    q = await engine.query_project_data("p", need, top_k=10, threshold=0.1)
+    # a subscription created with the SAME params must yield the same matches,
+    # even though the engine's defaults (threshold 0.9 / max 1) would differ
+    sub_id = await engine.subscriptions.create("p", [need], top_k=10, threshold=0.1)
+    bundle = await engine.subscriptions.get_bundle(sub_id)
+    assert [m["data_key"] for m in q] == [m["data_key"] for m in bundle[need]]
+    assert len(bundle[need]) >= 1

--- a/tests/test_subscription_params.py
+++ b/tests/test_subscription_params.py
@@ -4,6 +4,29 @@ from src.core.models import DataPublishEvent
 
 
 @pytest.mark.asyncio
+async def test_reconcile_honors_persisted_params(db, redis):
+    # engine default max_matches=1 (restrictive); subscription created with top_k=10 (permissive)
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=1)
+    await engine.initialize()
+    sub_id = await engine.subscriptions.create("p", ["database connection settings"], top_k=10, threshold=0.1)
+    # publish an array of objects — each element becomes a separate node, guaranteeing multiple
+    # matching nodes exist for a semantic query against "database connection settings"
+    await engine.publish_data(DataPublishEvent(
+        project_id="p", data_key="db",
+        data=[
+            {"purpose": "database connection settings", "host": "localhost", "port": 5432},
+            {"purpose": "database connection settings replica", "host": "replica.db", "port": 5432},
+            {"purpose": "database connection pool settings", "max_conn": 10, "min_conn": 2},
+        ],
+        data_format="json",
+    ))
+    bundle = await engine.subscriptions.get_bundle(sub_id)
+    total = sum(len(v) for v in bundle.values())
+    # if reconcile used the engine default (max_matches=1) this would be 1; the persisted top_k=10 must win
+    assert total > 1, f"reconcile ignored persisted top_k; got {total} matches"
+
+
+@pytest.mark.asyncio
 async def test_create_with_params_matches_query_with_same_params(db, redis):
     engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.9, max_matches=1)
     await engine.initialize()

--- a/tests/test_subscription_reconcile.py
+++ b/tests/test_subscription_reconcile.py
@@ -9,7 +9,7 @@ class _MutableMatcher:
     def __init__(self, bundle):
         self._bundle = bundle
 
-    async def match(self, project_id, needs, metadata=None):
+    async def match(self, project_id, needs, metadata=None, top_k=None, threshold=None):
         return {n: self._bundle for n in needs}
 
 
@@ -18,7 +18,7 @@ class _KeyedMatcher:
     def __init__(self, bundles):  # bundles: dict[need -> list]
         self.bundles = bundles
 
-    async def match(self, project_id, needs, metadata=None):
+    async def match(self, project_id, needs, metadata=None, top_k=None, threshold=None):
         return {n: list(self.bundles.get(n, [])) for n in needs}
 
 
@@ -107,7 +107,7 @@ async def test_reconcile_scoped_to_project(db, redis):
             self._call_count = 0
             self.bundles = {"need_o": list(other_initial)}
 
-        async def match(self, project_id, needs, metadata=None):
+        async def match(self, project_id, needs, metadata=None, top_k=None, threshold=None):
             self._call_count += 1
             # Always return a "different" bundle so any cross-project reconcile would be detected
             return {n: [{"data_key": "ok", "similarity": 0.5, "data": {"v": self._call_count}, "description": None}] for n in needs}

--- a/tests/test_subscription_service.py
+++ b/tests/test_subscription_service.py
@@ -3,7 +3,7 @@ from src.core.subscriptions import SubscriptionService
 
 
 class _StubMatcher:
-    async def match(self, project_id, needs, metadata=None):
+    async def match(self, project_id, needs, metadata=None, top_k=None, threshold=None):
         return {n: [{"data_key": "cfg", "similarity": 0.9, "data": {"x": 1}, "description": "auth"}] for n in needs}
 
 


### PR DESCRIPTION
## MCP Server Layer (Plan B) — context that updates itself, over MCP

Third increment of the reposition. Exposes Contex as an **MCP server** on **mcp 2.0**, delivering the headline experience: an agent subscribes to a natural-language need and gets a resource that **updates itself live** as matching data changes. Builds on Plan A (persistent subscriptions + reconcile) and the framework upgrade (which enabled mcp 2.0).

Design spec: `docs/superpowers/specs/2026-08-18-semantic-subscriptions-design.md` (§2, §4.1)
Plan: `docs/superpowers/plans/2026-08-18-mcp-server-layer.md`

### What's in it (13 commits)
- **`src/core/mcp_adapter.py`** — `build_mcp_server(engine)` (mcp 2.0 `MCPServer` + `InMemorySubscriptionBus`):
  - Tools: `contex_query`, `contex_create_subscription`, `contex_delete_subscription`, `contex_publish` — thin delegates to `ContextEngine`/`SubscriptionService`.
  - Resource: `contex://subscriptions/{id}` — returns a subscription's materialized bundle (the pull).
  - Lazy engine accessor (module-level build, engine resolved at call time via `isinstance(engine, ContextEngine)`) so `/mcp` is routable at import while the engine is created in the lifespan.
- **`src/core/mcp_bridge.py`** — turns Plan A's Redis `subscription:{id}:updated` events into MCP `resources/updated` pushes (`bus.publish(ResourceUpdated(uri=...))`). Poison-message resilient (a bad payload or a throwing subscriber can't kill the loop).
- **`main.py`** — mounts `/mcp`, enters the transport `session_manager.run()` in the lifespan (mounted sub-apps don't get their own lifespan run), starts the bridge task, makes `shutdown_cleanup` unconditional.
- **Task 1** — threaded explicit `top_k`/`threshold` through matcher+create for query/subscription parity.
- **End-to-end test** — proves the loop with strict assertions: publish → reconcile → `resources/updated` for the correct URI → re-read shows the refreshed bundle.

### Anti-corruption boundary
All `mcp` SDK imports are confined to `mcp_adapter.py` + `mcp_bridge.py` (verified in the final review; `main.py` uses only `build_mcp_server`/`run_bridge`). A future mcp 2.x→3.x migration is a two-module swap.

### Notable fix from the final whole-branch review
The per-task reviews passed, but the final review caught a real defect: `top_k`/`threshold` were applied at subscription *creation* but never **persisted**, so `reconcile_project` recomputed bundles with engine defaults on the next publish — silently breaking the §4.1 "what you test is what you get" guarantee on every update. Fixed: persisted on the `Subscription` model (**migration `004`**), threaded through `reconcile_project`, with a new reconcile-time parity test that fails if the persisted params are ignored.

### Tests
391 passed, 18 skipped. The 6 failing `sdk/python` tests are **pre-existing on `main`** (SDK models out of sync); this branch touches nothing under `sdk/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
