### PR TITLE
fix: demo-enablement fixes (compose build, IPv4 bind, sandbox render) + repo hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ dmypy.json
 
 # Playwright MCP scratch artifacts
 .playwright-mcp/
+
+# Superpowers SDD ledgers / workflow scratch
+.superpowers/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Multi-stage build for Context Engine Service
 FROM --platform=linux/amd64 python:3.11-slim@sha256:a0939570b38cddeb861b8e75d20b1c8218b21562b18f301171904b544e8cf228 as builder
 
+# Harden APT against "Hash Sum mismatch" from proxies/pipelining
+RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::BrokenProxy "true";\nAcquire::Retries "3";\n' > /etc/apt/apt.conf.d/99fixbadproxy
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     gcc \
@@ -25,6 +28,9 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 # Production stage
 FROM --platform=linux/amd64 python:3.11-slim@sha256:a0939570b38cddeb861b8e75d20b1c8218b21562b18f301171904b544e8cf228
+
+# Harden APT against "Hash Sum mismatch" from proxies/pipelining
+RUN printf 'Acquire::http::Pipeline-Depth "0";\nAcquire::http::No-Cache "true";\nAcquire::BrokenProxy "true";\nAcquire::Retries "3";\n' > /etc/apt/apt.conf.d/99fixbadproxy
 
 # Install curl for healthcheck
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Contex delivers relevant project context to AI agents using semantic matching. A
 Two terminals, `curl` only. Auth is off by default, so there's nothing to configure.
 
 ```bash
-docker compose up          # Postgres + Redis + app on http://localhost:8000
+docker compose up          # Postgres + Redis + app on http://localhost:8001
 ```
 
 **Terminal A — a consumer subscribes to a *need* and streams live context:**
 
 ```bash
-curl -N "http://localhost:8000/sandbox/subscribe?project_id=quickstart&need=how%20the%20service%20reaches%20its%20datastore"
+curl -N "http://localhost:8001/sandbox/subscribe?project_id=quickstart&need=how%20the%20service%20reaches%20its%20datastore"
 ```
 
 It prints the current matched context, then holds the stream open.
@@ -27,7 +27,7 @@ It prints the current matched context, then holds the stream open.
 **Terminal B — a producer publishes data (note: no shared words with the need):**
 
 ```bash
-curl -X POST http://localhost:8000/api/v1/data/publish \
+curl -X POST http://localhost:8001/api/v1/data/publish \
   -H "Content-Type: application/json" \
   -d '{"project_id":"quickstart","data_key":"pg_dsn",
        "data":{"engine":"postgres","host":"db.internal","port":5432,"pool":20}}'
@@ -38,13 +38,13 @@ producer, and matched on *meaning* ("datastore") not keywords. Change it again a
 watch it stay current:
 
 ```bash
-curl -X POST http://localhost:8000/api/v1/data/publish \
+curl -X POST http://localhost:8001/api/v1/data/publish \
   -H "Content-Type: application/json" \
   -d '{"project_id":"quickstart","data_key":"pg_dsn",
        "data":{"engine":"postgres","host":"db-2.internal","port":6543,"pool":50}}'
 ```
 
-Prefer a UI? Open `http://localhost:8000/sandbox`, pick a project, type a need, and hit
+Prefer a UI? Open `http://localhost:8001/sandbox`, pick a project, type a need, and hit
 **Watch** — the same live subscription, in the query editor.
 
 ![Contex Watch mode](docs/assets/demo.gif)

--- a/docs/demo/capture.md
+++ b/docs/demo/capture.md
@@ -6,10 +6,10 @@ The supporting GIF shows the sandbox query editor in **Watch** mode: publish a c
 1. Start the stack: `docker compose up` (images build `--platform linux/amd64`).
 2. Publish a couple of items so there's something to match, e.g.:
    ```bash
-   curl -X POST http://localhost:8000/api/v1/data/publish -H "Content-Type: application/json" \
+   curl -X POST http://localhost:8001/api/v1/data/publish -H "Content-Type: application/json" \
      -d '{"project_id":"quickstart","data_key":"pg_dsn","data":{"engine":"postgres","host":"db.internal","port":5432}}'
    ```
-3. Open `http://localhost:8000/sandbox`, select the `quickstart` project, type a need such as
+3. Open `http://localhost:8001/sandbox`, select the `quickstart` project, type a need such as
    *"how the service reaches its datastore"*, and click **Watch**. The results pane populates.
 4. Start a screen recorder scoped to the browser window.
 5. In another terminal, publish a change to `pg_dsn` (new `host`/`port`). Record the matching

--- a/main.py
+++ b/main.py
@@ -446,6 +446,6 @@ except Exception as e:
 
 if __name__ == "__main__":
     import uvicorn
-    host = os.getenv("CONTEX_HOST", "::")
+    host = os.getenv("CONTEX_HOST", "0.0.0.0")
     port = int(os.getenv("CONTEX_PORT", "8001"))
     uvicorn.run(app, host=host, port=port)

--- a/src/web/routes.py
+++ b/src/web/routes.py
@@ -8,8 +8,11 @@ from fastapi.templating import Jinja2Templates
 from pathlib import Path
 import toon_format as toon
 from src.web.live import stream_subscription_updates
+from src.core.logging import get_logger
 
 router = APIRouter()
+
+logger = get_logger(__name__)
 
 # Setup templates
 templates_dir = Path(__file__).parent / "templates"
@@ -21,20 +24,20 @@ async def sandbox_home(request: Request):
     """Query sandbox home page"""
     engine = request.app.state.context_engine
 
-    # Get all available projects from Redis
+    # Get all available projects from the embeddings store (Postgres/pgvector),
+    # which is where published data actually lands.
     projects = set()
     try:
-        from redis.commands.search.query import Query
-        q = Query("*").return_fields("project_id").paging(0, 1000)
-        results = await engine.semantic_matcher.redis.ft(
-            engine.semantic_matcher.INDEX_NAME
-        ).search(q)
+        from sqlalchemy import select
+        from src.core.db_models import Embedding
 
-        for doc in results.docs:
-            projects.add(doc.project_id)
-    except:
-        # Index might not exist yet
-        pass
+        async with engine.semantic_matcher.db.session() as session:
+            result = await session.execute(
+                select(Embedding.project_id).distinct()
+            )
+            projects.update(row[0] for row in result.all())
+    except Exception as e:
+        logger.warning("Failed to list projects for sandbox", error=str(e))
 
     return templates.TemplateResponse(
         request,
@@ -219,58 +222,42 @@ async def project_stats(request: Request, project_id: str):
 @router.get("/projects/{project_id}/data")
 async def get_project_data(request: Request, project_id: str):
     """Get all data for a project (JSON endpoint for sandbox UI)"""
-    import json
+    from sqlalchemy import select
+    from src.core.db_models import Embedding
 
     engine = request.app.state.context_engine
 
-    # Get all unique data_keys for this project
-    data_keys = await engine.semantic_matcher.get_registered_data(project_id)
+    # One representative row per data_key, straight from the embeddings store.
+    # DISTINCT ON collapses the per-node rows back to a single item per key.
+    async with engine.semantic_matcher.db.session() as session:
+        result = await session.execute(
+            select(
+                Embedding.data_key,
+                Embedding.data,
+                Embedding.data_original,
+                Embedding.data_format,
+            )
+            .where(Embedding.project_id == project_id)
+            .distinct(Embedding.data_key)
+            .order_by(Embedding.data_key, Embedding.id)
+        )
+        rows = result.all()
 
     data_items = []
+    for data_key, data, data_original, data_format in rows:
+        # Prefer the full original payload (pre node-splitting); fall back to the JSONB node data.
+        data_obj = data
+        if data_original:
+            try:
+                data_obj = json.loads(data_original)
+            except (json.JSONDecodeError, ValueError):
+                data_obj = data_original
 
-    # For each data_key, find one node and get its data_original field
-    for key in data_keys:
-        # Find any node for this data_key using SCAN
-        pattern = f"{engine.semantic_matcher.KEY_PREFIX}{project_id}:{key}*"
-        cursor = 0
-        found = False
-
-        while not found:
-            cursor, keys = await engine.semantic_matcher.redis.scan(
-                cursor, match=pattern, count=1
-            )
-
-            if keys:
-                # Get first matching node
-                node_key = keys[0]
-                data_info = await engine.semantic_matcher.redis.hgetall(node_key)
-
-                if data_info:
-                    # Extract data_original (full original data before node splitting)
-                    data_original_str = data_info.get(b"data_original") or data_info.get("data_original")
-                    if isinstance(data_original_str, bytes):
-                        data_original_str = data_original_str.decode()
-
-                    # Extract format
-                    data_format = data_info.get(b"data_format") or data_info.get("data_format", "unknown")
-                    if isinstance(data_format, bytes):
-                        data_format = data_format.decode()
-
-                    # Parse data
-                    try:
-                        data_obj = json.loads(data_original_str)
-                    except (json.JSONDecodeError, ValueError):
-                        data_obj = data_original_str
-
-                    data_items.append({
-                        "data_key": key,
-                        "description": f"{key} ({data_format})",
-                        "data": data_obj
-                    })
-                    found = True
-
-            if cursor == 0:
-                break
+        data_items.append({
+            "data_key": data_key,
+            "description": f"{data_key} ({data_format or 'unknown'})",
+            "data": data_obj,
+        })
 
     return {"data": data_items}
 

--- a/src/web/routes.py
+++ b/src/web/routes.py
@@ -7,8 +7,11 @@ from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from pathlib import Path
 import toon_format as toon
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from src.web.live import stream_subscription_updates
 from src.core.logging import get_logger
+from src.core.db_models import Embedding
 
 router = APIRouter()
 
@@ -28,15 +31,16 @@ async def sandbox_home(request: Request):
     # which is where published data actually lands.
     projects = set()
     try:
-        from sqlalchemy import select
-        from src.core.db_models import Embedding
-
         async with engine.semantic_matcher.db.session() as session:
             result = await session.execute(
                 select(Embedding.project_id).distinct()
             )
             projects.update(row[0] for row in result.all())
-    except Exception as e:
+    except SQLAlchemyError as e:
+        # Non-critical: this only populates the project dropdown. If the store
+        # is briefly unreachable (or the table doesn't exist yet on a fresh DB),
+        # render the page with an empty list instead of 500ing. Unexpected
+        # (non-DB) errors propagate so real bugs surface rather than hide here.
         logger.warning("Failed to list projects for sandbox", error=str(e))
 
     return templates.TemplateResponse(
@@ -222,9 +226,6 @@ async def project_stats(request: Request, project_id: str):
 @router.get("/projects/{project_id}/data")
 async def get_project_data(request: Request, project_id: str):
     """Get all data for a project (JSON endpoint for sandbox UI)"""
-    from sqlalchemy import select
-    from src.core.db_models import Embedding
-
     engine = request.app.state.context_engine
 
     # One representative row per data_key, straight from the embeddings store.

--- a/src/web/templates/sandbox.html
+++ b/src/web/templates/sandbox.html
@@ -53,9 +53,9 @@
             for (const m of matches) items.push(m);
         }
         const nextByKey = {};
-        let html = '<div class="watch-results">';
+        let html = '<div class=&quot;watch-results&quot;>';
         if (!items.length) {
-            html += '<div class="placeholder"><p>Watching — no matching context yet. '
+            html += '<div class=&quot;placeholder&quot;><p>Watching — no matching context yet. '
                  +  'Publish data to this project to see it appear.</p></div>';
         }
         for (const m of items) {
@@ -63,8 +63,8 @@
             nextByKey[m.data_key] = serialized;
             const changed = this.watchLastByKey[m.data_key] !== undefined
                          && this.watchLastByKey[m.data_key] !== serialized;
-            html += '<div class="watch-item' + (changed ? ' flash' : '') + '">'
-                 +  '<div class="watch-key"></div><pre></pre></div>';
+            html += '<div class=&quot;watch-item' + (changed ? ' flash' : '') + '&quot;>'
+                 +  '<div class=&quot;watch-key&quot;></div><pre></pre></div>';
         }
         html += '</div>';
         results.innerHTML = html;


### PR DESCRIPTION
Bundles the verified fixes from the debugging/demo-enablement work that were sitting uncommitted in the working tree, plus one hygiene change. Four atomic commits.

### Fixes
- **`docker compose up` now builds and serves** — APT hardening against "Hash Sum mismatch" (both build stages); `CONTEX_HOST` defaults to `0.0.0.0` so Docker's IPv4 port forward reaches uvicorn (was IPv6-only → `curl` exit 52).
- **Sandbox renders and lists projects** — escape the Alpine `x-data` inner quotes as `&quot;` (JS was leaking into the page as text); rewrite `sandbox_home` + `get_project_data` to read from the `embeddings` table instead of dead RediSearch code (fixes "No Projects Yet" and the 500 on project data).
- **Quickstart port** corrected `8000` → `8001` in README + demo capture (app serves on 8001).

### Hygiene
- gitignore `.superpowers/` (SDD ledgers / audit manifests — process scratch).

### Related audit issues (not closed by this PR)
- #107 — `project_stats` still has dead RediSearch attrs; this PR fixes the *sibling* handlers only.
- #100 — this sets `main.py` to `0.0.0.0`; `.env.example` still says `::` and should be aligned separately.

### Note
The port-correction commit (README/`capture.md`) was already modified in the working tree at the start of the session — included here because it's correct and part of the same demo-enablement cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)