### PR TITLE
ci: fresh-DB migrate + boot + publish/query smoke gate (#119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,80 @@ jobs:
       run: |
         pytest tests/ -v --tb=short
 
+  fresh-db-boot:
+    name: Fresh-DB Migrate + Boot Smoke
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: contex_test
+          POSTGRES_USER: contex
+          POSTGRES_PASSWORD: contex_password
+        options: >-
+          --health-cmd "pg_isready -U contex -d contex_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Cache Python dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Wait for services
+      run: |
+        echo "Waiting for PostgreSQL..."
+        until pg_isready -h localhost -p 5432 -U contex; do
+          echo "PostgreSQL not ready, waiting..."
+          sleep 2
+        done
+        echo "PostgreSQL is ready!"
+
+    - name: Enable pgvector extension
+      env:
+        PGPASSWORD: contex_password
+      run: |
+        psql -h localhost -U contex -d contex_test -c "CREATE EXTENSION IF NOT EXISTS vector;"
+        echo "pgvector extension enabled"
+
+    - name: Migrate empty DB, boot app, smoke publish -> query
+      env:
+        DATABASE_URL: postgresql+asyncpg://contex:contex_password@localhost:5432/contex_test
+        REDIS_URL: redis://localhost:6379
+      run: |
+        python scripts/fresh_db_boot_smoke.py
+
   docker:
     name: Verify Docker Build
     runs-on: ubuntu-latest

--- a/scripts/fresh_db_boot_smoke.py
+++ b/scripts/fresh_db_boot_smoke.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Fresh-DB boot smoke test (CI gate for issue #119).
+
+Run against an EMPTY Postgres (pgvector) + Redis. Asserts, in order:
+
+1. ``alembic upgrade head`` brought the DB to the alembic head revision
+   (the ``alembic_version`` row matches ``alembic heads``).
+2. The app boots (its ``main.py`` lifespan calls ``db.migrate_to_head()``).
+3. ``GET /health`` returns a healthy status.
+4. ONE end-to-end publish -> query round-trip succeeds.
+
+This catches fresh-install / migration / boot regressions that unit tests miss.
+Exit code 0 on success, non-zero (with a printed reason) on any failure.
+
+Expects ``DATABASE_URL`` (postgresql+asyncpg://...) and ``REDIS_URL`` in the env.
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+import httpx
+
+
+def _fail(msg: str) -> "None":
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def assert_alembic_at_head() -> None:
+    """Assert the DB is stamped at the alembic head revision."""
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    config = Config("alembic.ini")
+    script = ScriptDirectory.from_config(config)
+    heads = set(script.get_heads())
+    print(f"alembic script heads: {sorted(heads)}")
+
+    # Read the applied revision(s) from the DB's alembic_version table. Use a
+    # sync psycopg-free path via asyncpg through SQLAlchemy's async engine.
+    import asyncio
+
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    async def _read_db_heads() -> set:
+        url = os.environ["DATABASE_URL"]
+        engine = create_async_engine(url)
+        try:
+            async with engine.connect() as conn:
+                result = await conn.execute(
+                    text("SELECT version_num FROM alembic_version")
+                )
+                return {row[0] for row in result.fetchall()}
+        finally:
+            await engine.dispose()
+
+    db_heads = asyncio.run(_read_db_heads())
+    print(f"alembic_version in DB: {sorted(db_heads)}")
+
+    if not db_heads:
+        _fail("alembic_version table is empty - migrations did not run")
+    if db_heads != heads:
+        _fail(f"DB revision {sorted(db_heads)} != script head {sorted(heads)}")
+    print("OK: database is at alembic head")
+
+
+def wait_for_health(base_url: str, proc: subprocess.Popen, timeout: float = 90.0) -> None:
+    """Poll GET /health until healthy or timeout; fail if the app died."""
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            _fail(f"app process exited early with code {proc.returncode}")
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=5.0)
+            if resp.status_code == 200 and resp.json().get("status") == "healthy":
+                print(f"OK: GET /health -> {resp.json()}")
+                return
+            last_err = f"status={resp.status_code} body={resp.text[:200]}"
+        except Exception as e:  # noqa: BLE001 - transient during boot
+            last_err = str(e)
+        time.sleep(1.0)
+    _fail(f"/health never became healthy: {last_err}")
+
+
+def round_trip(base_url: str) -> None:
+    """One end-to-end publish -> query round-trip."""
+    api = f"{base_url}/api/v1"
+    project_id = "ci-smoke-proj"
+
+    pub = httpx.post(
+        f"{api}/data/publish",
+        json={
+            "project_id": project_id,
+            "data_key": "auth_method",
+            "data": {
+                "authentication": "OAuth2 with JWT bearer tokens",
+                "provider": "Auth0",
+            },
+        },
+        timeout=30.0,
+    )
+    if pub.status_code != 200:
+        _fail(f"publish returned {pub.status_code}: {pub.text[:300]}")
+    print(f"OK: published data -> {pub.json()}")
+
+    # Query it back (JSON format for easy assertion). Retry briefly to allow
+    # for any eventual-consistency in indexing.
+    deadline = time.time() + 30.0
+    last = None
+    while time.time() < deadline:
+        q = httpx.post(
+            f"{api}/projects/{project_id}/query",
+            json={
+                "query": "what authentication method do we use",
+                "top_k": 3,
+                # Low threshold so the round-trip is robust to embedding-model
+                # scoring; we only need to prove data flows publish -> query.
+                "threshold": 0.0,
+                "response_format": "json",
+            },
+            timeout=30.0,
+        )
+        if q.status_code != 200:
+            _fail(f"query returned {q.status_code}: {q.text[:300]}")
+        body = q.json()
+        last = body
+        if body.get("total_matches", 0) >= 1 and body.get("matches"):
+            print(f"OK: query round-trip returned {body['total_matches']} match(es)")
+            return
+        time.sleep(1.0)
+    _fail(f"query round-trip returned no matches: {last}")
+
+
+def main() -> None:
+    if "DATABASE_URL" not in os.environ:
+        _fail("DATABASE_URL not set")
+
+    # 1) Migrate the empty DB and assert head is reached.
+    print("== Running alembic upgrade head ==")
+    subprocess.run(["alembic", "upgrade", "head"], check=True)
+    assert_alembic_at_head()
+
+    # 2) Boot the app (lifespan re-runs migrate_to_head; idempotent).
+    host = "127.0.0.1"
+    port = "8123"
+    base_url = f"http://{host}:{port}"
+    env = dict(os.environ)
+    env.setdefault("AUTH_ENABLED", "false")
+    env.setdefault("LOG_JSON", "false")
+    env.setdefault("WEBHOOKS_ENABLED", "false")
+
+    print("== Booting app ==")
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "main:app", "--host", host, "--port", port],
+        env=env,
+    )
+    try:
+        # 3) /health healthy.
+        wait_for_health(base_url, proc)
+        # 4) publish -> query round-trip.
+        round_trip(base_url)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    print("\nfresh-DB boot smoke test PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a `fresh-db-boot` CI job that verifies the documented fresh-install / `docker compose up` path on every commit — the gap flagged in #119.

Against an **empty** `pgvector/pgvector:pg16` Postgres (+ Redis, standing up services the same way the existing "Run Test Suite" job does), the job runs `scripts/fresh_db_boot_smoke.py`, which:

1. Runs `alembic upgrade head` and asserts the DB reaches the alembic head (`alembic_version` matches `alembic heads`; currently `005`).
2. Boots the app (`main.py` lifespan re-runs `db.migrate_to_head()`).
3. Asserts `GET /health` returns `status: healthy`.
4. Performs ONE end-to-end publish -> query round-trip and asserts a match comes back.

This is the single "migrate a clean DB, boot, smoke one request" gate whose absence let a cluster of fresh-DB/boot regressions (#102/#103/#106/#108) ship undetected.

## Commits

- `test(ci):` add the standalone smoke script.
- `ci:` wire it into `.github/workflows/ci.yml` as a new job.

## Verification

- Smoke script run locally against a fresh empty `pgvector/pgvector:pg16` + Redis: all four assertions PASS.
- `pytest tests/ -q`: **377 passed**, 0 failures (no new failures introduced).

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZnLF4dWe5WnQpsixziUaQ