### PR TITLE
fix(versioning): repair version endpoints (real EventStore method) (#106)

### DIFF
--- a/src/api/version_routes.py
+++ b/src/api/version_routes.py
@@ -13,18 +13,11 @@ router = APIRouter(prefix="/api/v1/versions", tags=["Versioning"])
 
 def _extract_version(event: dict, data_key: str) -> dict | None:
     """
-    Project a raw EventStore event onto a version record for ``data_key``.
+    Project an event onto a version record, or return ``None`` if the event
+    does not concern ``data_key``.
 
-    EventStore events have the shape::
-
-        {"sequence": "<n>", "event_type": "<type>", "data": {data_key: <value>}}
-
-    (see ``EventStore.get_all_events`` / ``ContextEngine.publish_data``). A publish
-    stores the payload under its ``data_key``, so an event is relevant to this
-    ``data_key`` iff that key is present in the event's ``data`` dict.
-
-    Returns a version dict for the requested key, or ``None`` if the event does
-    not concern this key.
+    Events have the shape ``{"sequence", "event_type", "data": {data_key: value}}``,
+    so an event is relevant iff ``data_key`` is present in its ``data`` dict.
     """
     event_data = event.get("data") or {}
     if not isinstance(event_data, dict) or data_key not in event_data:

--- a/src/api/version_routes.py
+++ b/src/api/version_routes.py
@@ -5,11 +5,36 @@ Instead of separate versioning system, versions are derived from event stream.
 """
 
 from fastapi import APIRouter, Request, HTTPException
-from typing import List, Optional
 from src.core.logging import get_logger
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/api/v1/versions", tags=["Versioning"])
+
+
+def _extract_version(event: dict, data_key: str) -> dict | None:
+    """
+    Project a raw EventStore event onto a version record for ``data_key``.
+
+    EventStore events have the shape::
+
+        {"sequence": "<n>", "event_type": "<type>", "data": {data_key: <value>}}
+
+    (see ``EventStore.get_all_events`` / ``ContextEngine.publish_data``). A publish
+    stores the payload under its ``data_key``, so an event is relevant to this
+    ``data_key`` iff that key is present in the event's ``data`` dict.
+
+    Returns a version dict for the requested key, or ``None`` if the event does
+    not concern this key.
+    """
+    event_data = event.get("data") or {}
+    if not isinstance(event_data, dict) or data_key not in event_data:
+        return None
+
+    return {
+        "sequence": event.get("sequence"),
+        "data": event_data.get(data_key),
+        "event_type": event.get("event_type"),
+    }
 
 
 @router.get("/projects/{project_id}/data/{data_key}/history")
@@ -33,32 +58,20 @@ async def get_version_history(
     try:
         engine = request.app.state.context_engine
 
-        # Get all events for this project
-        all_events = await engine.event_store.get_events(project_id, since="0", count=10000)
+        # TODO(#120): full-scan of the project's event log. This loads up to
+        # 10k events into memory and filters in Python; replace with a
+        # key-scoped query once #120 lands.
+        all_events = await engine.event_store.get_all_events(project_id, count=10000)
 
-        # Filter to events for this data_key
         versions = []
         for event in all_events:
-            event_data = event.get("data", {})
-            if isinstance(event_data, str):
-                import json
-                try:
-                    event_data = json.loads(event_data)
-                except:
-                    continue
+            version = _extract_version(event, data_key)
+            if version is not None:
+                versions.append(version)
 
-            if event_data.get("data_key") == data_key:
-                versions.append({
-                    "sequence": event.get("id"),
-                    "timestamp": event.get("id").split("-")[0] if "-" in event.get("id", "") else event.get("id"),
-                    "data": event_data.get("data"),
-                    "data_format": event_data.get("data_format", "json"),
-                    "description": event_data.get("description"),
-                    "event_type": event_data.get("event_type"),
-                })
-
-        # Sort by sequence (most recent first) and limit
-        versions.sort(key=lambda x: x["sequence"], reverse=True)
+        # Sort by sequence (most recent first) and limit. Sequences are
+        # monotonic integers-as-strings, so sort numerically.
+        versions.sort(key=lambda v: int(v["sequence"]), reverse=True)
         versions = versions[:limit]
 
         return {
@@ -97,30 +110,23 @@ async def get_specific_version(
     try:
         engine = request.app.state.context_engine
 
-        # Get events up to this sequence
-        all_events = await engine.event_store.get_events(project_id, since="0", count=10000)
+        # TODO(#120): full-scan of the project's event log to find one sequence;
+        # replace with a direct sequence lookup once #120 lands.
+        all_events = await engine.event_store.get_all_events(project_id, count=10000)
 
-        # Find the specific version
         for event in all_events:
-            if event.get("id") == sequence:
-                event_data = event.get("data", {})
-                if isinstance(event_data, str):
-                    import json
-                    try:
-                        event_data = json.loads(event_data)
-                    except:
-                        raise HTTPException(status_code=500, detail="Failed to parse event data")
+            if event.get("sequence") != sequence:
+                continue
 
-                if event_data.get("data_key") == data_key:
-                    return {
-                        "project_id": project_id,
-                        "data_key": data_key,
-                        "sequence": sequence,
-                        "timestamp": sequence.split("-")[0] if "-" in sequence else sequence,
-                        "data": event_data.get("data"),
-                        "data_format": event_data.get("data_format", "json"),
-                        "description": event_data.get("description"),
-                    }
+            version = _extract_version(event, data_key)
+            if version is not None:
+                return {
+                    "project_id": project_id,
+                    "data_key": data_key,
+                    "sequence": sequence,
+                    "data": version["data"],
+                    "event_type": version["event_type"],
+                }
 
         raise HTTPException(status_code=404, detail=f"Version {sequence} not found for {data_key}")
 
@@ -190,6 +196,11 @@ async def restore_version(
     """
     Restore data to a specific version (creates new event with old data).
 
+    SECURITY: This is an UNAUTHENTICATED mutation. Anyone who can reach this
+    endpoint can restore a data key to an arbitrary prior version. Auth is
+    deliberately out of scope here and is tracked by issue #72 (Tier-0 auth
+    foundation); wire an authorization check in once #72 lands.
+
     Args:
         project_id: Project identifier
         data_key: Data key
@@ -210,10 +221,8 @@ async def restore_version(
             project_id=project_id,
             data_key=data_key,
             data=version.get("data"),
-            data_format=version.get("data_format"),
             event_type=f"data.restored.{data_key}",
         )
-        restore_event.description = f"Restored to version {sequence}"
 
         new_sequence = await engine.publish_data(restore_event)
 

--- a/tests/test_version_routes.py
+++ b/tests/test_version_routes.py
@@ -1,0 +1,143 @@
+"""
+Integration tests for the data-versioning API (src/api/version_routes.py).
+
+Regression coverage for issue #106: the routes previously called the
+non-existent ``EventStore.get_events()`` and 500'd on every request. These
+tests drive all four endpoints (history / version / diff / restore) against a
+real ContextEngine backed by the live Postgres event store and assert they
+return 200 for a normal case.
+"""
+
+import numpy as np
+import pytest
+import pytest_asyncio
+from unittest.mock import Mock, patch
+
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from src.api.version_routes import router as version_router
+from src.core.context_engine import ContextEngine
+from src.core.models import DataPublishEvent
+
+
+@pytest_asyncio.fixture
+async def engine(db, redis):
+    """Real ContextEngine on the live test DB, with the heavy embedding model mocked."""
+    with patch("src.core.semantic_matcher.SentenceTransformer") as mock_model_cls:
+        mock_model = Mock()
+        mock_model.encode.return_value = np.array([0.1] * 384, dtype=np.float32)
+        mock_model_cls.return_value = mock_model
+
+        engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.5, max_matches=10)
+        if hasattr(engine.semantic_matcher, "initialize_index"):
+            await engine.semantic_matcher.initialize_index()
+        yield engine
+
+
+@pytest_asyncio.fixture
+async def client(engine):
+    """FastAPI app mounting only the versioning router, wired to the real engine."""
+    app = FastAPI()
+    app.include_router(version_router)
+    app.state.context_engine = engine
+    async with AsyncClient(app=app, base_url="http://test") as c:
+        yield c
+
+
+async def _publish(engine, project_id, data_key, data):
+    return await engine.publish_data(
+        DataPublishEvent(project_id=project_id, data_key=data_key, data=data)
+    )
+
+
+@pytest.mark.asyncio
+async def test_history_returns_200_with_versions(engine, client):
+    project_id = "ver-proj"
+    data_key = "tech_stack"
+    await _publish(engine, project_id, data_key, {"db": "postgres"})
+    await _publish(engine, project_id, data_key, {"db": "postgres", "cache": "redis"})
+    # An unrelated key must not leak into this key's history.
+    await _publish(engine, project_id, "other_key", {"unrelated": True})
+
+    resp = await client.get(f"/api/v1/versions/projects/{project_id}/data/{data_key}/history")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["count"] == 2
+    assert len(body["versions"]) == 2
+    # Most-recent first.
+    assert body["versions"][0]["data"] == {"db": "postgres", "cache": "redis"}
+    assert body["versions"][1]["data"] == {"db": "postgres"}
+
+
+@pytest.mark.asyncio
+async def test_history_empty_key_returns_200(client):
+    resp = await client.get(
+        "/api/v1/versions/projects/ver-proj/data/does_not_exist/history"
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["count"] == 0
+    assert body["versions"] == []
+
+
+@pytest.mark.asyncio
+async def test_specific_version_returns_200(engine, client):
+    project_id = "ver-proj"
+    data_key = "config"
+    seq = await _publish(engine, project_id, data_key, {"level": "info"})
+
+    resp = await client.get(
+        f"/api/v1/versions/projects/{project_id}/data/{data_key}/version/{seq}"
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["sequence"] == seq
+    assert body["data"] == {"level": "info"}
+
+
+@pytest.mark.asyncio
+async def test_diff_returns_200(engine, client):
+    project_id = "ver-proj"
+    data_key = "config"
+    seq1 = await _publish(engine, project_id, data_key, {"level": "info"})
+    seq2 = await _publish(engine, project_id, data_key, {"level": "debug"})
+
+    resp = await client.get(
+        f"/api/v1/versions/projects/{project_id}/data/{data_key}/diff",
+        params={"from_sequence": seq1, "to_sequence": seq2},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["from_data"] == {"level": "info"}
+    assert body["to_data"] == {"level": "debug"}
+    assert body["changed"] is True
+
+
+@pytest.mark.asyncio
+async def test_restore_returns_200_and_appends_event(engine, client):
+    project_id = "ver-proj"
+    data_key = "config"
+    seq1 = await _publish(engine, project_id, data_key, {"level": "info"})
+    await _publish(engine, project_id, data_key, {"level": "debug"})
+
+    resp = await client.post(
+        f"/api/v1/versions/projects/{project_id}/data/{data_key}/restore/{seq1}"
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["restored_from"] == seq1
+    assert body["data"] == {"level": "info"}
+    # Restoration appends a brand-new event whose sequence is beyond the originals.
+    assert int(body["new_sequence"]) > int(seq1)
+
+    # The restored value is now the newest version in history.
+    hist = await client.get(
+        f"/api/v1/versions/projects/{project_id}/data/{data_key}/history"
+    )
+    assert hist.status_code == 200
+    assert hist.json()["versions"][0]["data"] == {"level": "info"}


### PR DESCRIPTION
## Summary

`src/api/version_routes.py` called a non-existent method — `EventStore.get_events(project_id, since=..., count=...)` — so all four versioning endpoints returned 500:

- `GET  /api/v1/versions/projects/{project_id}/data/{data_key}/history`
- `GET  /api/v1/versions/projects/{project_id}/data/{data_key}/version/{sequence}`
- `GET  /api/v1/versions/projects/{project_id}/data/{data_key}/diff`
- `POST /api/v1/versions/projects/{project_id}/data/{data_key}/restore/{sequence}`

## What changed

- Swapped the non-existent call for the **real** method **`EventStore.get_all_events(project_id, count=...)`** (verified in `src/core/event_store.py`). `get_events_since` was considered but `get_all_events` is the correct fit here: version history needs the full log for a key, and the endpoint already applied its own count cap.
- The routes were also written against a **stale (pre-repositioning) Redis event shape** — `event["id"]`, plus nested `data_key`/`data_format`/`description`. Rewrote the projection to the **real Postgres event shape** returned by `get_all_events`:
  `{"sequence": str, "event_type": str, "data": {data_key: <value>}}`.
  A publish stores its payload under its `data_key` (see `ContextEngine.publish_data`), so an event is relevant to a `data_key` iff that key is present in `event["data"]`. Sequences are sorted numerically (most-recent-first).
- Added `tests/test_version_routes.py`: integration tests driving all four endpoints against a real `ContextEngine` on the live Postgres event store, asserting 200 for a normal case plus history ordering and restore semantics.

## Scope fences (deliberately NOT crossed — separate issues)

- **Auth (#72):** `restore` remains an **UNAUTHENTICATED mutation** until the Tier-0 auth foundation lands. Anyone who can reach the endpoint can restore a data key to an arbitrary prior version. This is documented in a `SECURITY:` docstring note on `restore_version`, and is out of scope here per #72. No authentication was added in this PR.
- **Full-scan perf (#120):** the history and single-version lookups still full-scan the project event log (up to 10k events, filtered in Python). Left as-is with a `# TODO(#120)` comment at **both** scan sites rather than fixed here.

## Testing

- New `tests/test_version_routes.py`: **5 passed** (against live `pgvector/pgvector:pg16` + Redis).
- Full `pytest tests/ -q`: **382 passed, 0 failed** (exit 0). No new failures under `tests/`. (The ~6 known-unrelated failures live under `sdk/python/tests`, not `tests/`, and were not run here.)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZnLF4dWe5WnQpsixziUaQ