### PR TITLE
fix(web): read sandbox project stats from embeddings table (#107)

### DIFF
--- a/src/web/routes.py
+++ b/src/web/routes.py
@@ -165,61 +165,68 @@ async def execute_query(
 
 @router.get("/projects/{project_id}/stats", response_class=HTMLResponse)
 async def project_stats(request: Request, project_id: str):
-    """Get statistics about a project's data"""
+    """Get statistics about a project's data.
+
+    Reads from the `embeddings` table (Postgres/pgvector) — the store where
+    published data actually lands — mirroring the sibling `/data` handler.
+    """
     engine = request.app.state.context_engine
 
-    # Get all data for this project
-    data_keys = await engine.semantic_matcher.get_registered_data(project_id)
+    # One representative row per data_key, straight from the embeddings store.
+    # DISTINCT ON collapses the per-node rows back to a single item per key.
+    async with engine.semantic_matcher.db.session() as session:
+        result = await session.execute(
+            select(
+                Embedding.data_key,
+                Embedding.description,
+                Embedding.data,
+                Embedding.data_original,
+            )
+            .where(Embedding.project_id == project_id)
+            .distinct(Embedding.data_key)
+            .order_by(Embedding.data_key, Embedding.id)
+        )
+        rows = result.all()
 
     # Calculate stats
     import tiktoken
     try:
         enc = tiktoken.get_encoding("cl100k_base")
-    except:
+    except Exception:
         enc = None
 
     total_tokens = 0
     data_items = []
 
-    # Fetch data from Redis for each key
-    for key in data_keys:
-        redis_key = f"{engine.semantic_matcher.KEY_PREFIX}{project_id}:{key}"
-        data_info = await engine.semantic_matcher.redis.hgetall(redis_key)
+    for data_key, description, data, data_original in rows:
+        # Prefer the full original payload (pre node-splitting); fall back to the
+        # JSONB node data serialized as JSON.
+        data_str = data_original if data_original else json.dumps(data)
 
-        if data_info:
-            # Decode bytes if needed
-            description = data_info.get(b"description") or data_info.get("description", "")
-            if isinstance(description, bytes):
-                description = description.decode()
+        # Calculate token count
+        token_count = 0
+        if enc:
+            try:
+                token_count = len(enc.encode(data_str))
+                total_tokens += token_count
+            except Exception:
+                pass
 
-            data_str = data_info.get(b"data") or data_info.get("data", "{}")
-            if isinstance(data_str, bytes):
-                data_str = data_str.decode()
-
-            # Calculate token count
-            token_count = 0
-            if enc:
-                try:
-                    token_count = len(enc.encode(data_str))
-                    total_tokens += token_count
-                except:
-                    pass
-
-            data_items.append({
-                "data_key": key,
-                "description": description,
-                "token_count": token_count
-            })
+        data_items.append({
+            "data_key": data_key,
+            "description": description or "",
+            "token_count": token_count,
+        })
 
     return templates.TemplateResponse(
+        request,
         "project_stats.html",
         {
-            "request": request,
             "project_id": project_id,
             "data_count": len(data_items),
             "total_tokens": total_tokens,
-            "data_items": sorted(data_items, key=lambda x: x["token_count"], reverse=True)
-        }
+            "data_items": sorted(data_items, key=lambda x: x["token_count"], reverse=True),
+        },
     )
 
 

--- a/tests/test_sandbox_watch.py
+++ b/tests/test_sandbox_watch.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import pytest
 
 from src.core.context_engine import ContextEngine
-from src.web.routes import sandbox_home, subscribe_to_updates
+from src.core.models import DataPublishEvent
+from src.web.routes import project_stats, sandbox_home, subscribe_to_updates
 
 
 def _request_with(engine):
@@ -29,6 +30,57 @@ async def test_subscribe_returns_event_stream(db, redis):
     resp = await subscribe_to_updates(_request_with(engine), project_id="p", need="database connection settings")
     assert resp.media_type == "text/event-stream"
     assert resp.headers["Cache-Control"] == "no-cache"
+
+
+@pytest.mark.asyncio
+async def test_project_stats_renders_from_embeddings(db, redis):
+    """Regression for #107: the stats handler must read from the embeddings
+    table (Postgres), not dead RediSearch attrs, and return 200-worthy stats."""
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+
+    await engine.publish_data(DataPublishEvent(
+        project_id="stats-proj", data_key="db",
+        data={"purpose": "database connection settings"}, data_format="json",
+        description="DB config",
+    ))
+    await engine.publish_data(DataPublishEvent(
+        project_id="stats-proj", data_key="auth",
+        data={"purpose": "auth token secret"}, data_format="json",
+        description="Auth config",
+    ))
+
+    resp = await project_stats(_request_with(engine), project_id="stats-proj")
+
+    assert resp.template.name == "project_stats.html"
+    ctx = resp.context
+    assert ctx["project_id"] == "stats-proj"
+    # Two distinct data_keys published.
+    assert ctx["data_count"] == 2
+    assert ctx["total_tokens"] > 0
+    keys = {item["data_key"] for item in ctx["data_items"]}
+    assert keys == {"db", "auth"}
+    # Every item carries a non-negative token count and a description field.
+    for item in ctx["data_items"]:
+        assert item["token_count"] >= 0
+        assert "description" in item
+    # Sorted by token_count descending.
+    counts = [item["token_count"] for item in ctx["data_items"]]
+    assert counts == sorted(counts, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_project_stats_empty_project(db, redis):
+    """An unknown project should render cleanly with zeroed stats, not 500."""
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+
+    resp = await project_stats(_request_with(engine), project_id="no-such-project")
+
+    assert resp.template.name == "project_stats.html"
+    assert resp.context["data_count"] == 0
+    assert resp.context["total_tokens"] == 0
+    assert resp.context["data_items"] == []
 
 
 def test_sandbox_template_has_watch_and_query_wiring():


### PR DESCRIPTION
## Summary

`GET /sandbox/projects/{id}/stats` always 500'd with an `AttributeError`: the handler still reached for `semantic_matcher.KEY_PREFIX` and `semantic_matcher.redis`, neither of which survived the OpenSearch → pgvector reposition.

This rewrites the stats handler to read from the `embeddings` table (Postgres/pgvector), mirroring the sibling `/data` handler (`get_project_data`) that #117 already fixed:

- Queries via `engine.semantic_matcher.db.session()` with `DISTINCT ON (data_key)` to collapse the per-node rows back to one item per data key.
- Token counts come from the original payload (`data_original`), falling back to the JSONB node `data`.
- Switches to the request-first `TemplateResponse` signature used by the other handlers in this module.

Scope is limited to the stats handler only — the ~28 inline imports flagged for #123 are left untouched to avoid conflicting with that future work.

## Tests

Added to `tests/test_sandbox_watch.py`, run against live `pgvector/pgvector:pg16` + Redis:

- `test_project_stats_renders_from_embeddings` — publishes two data keys, asserts `data_count`, positive `total_tokens`, correct keys, and descending token sort.
- `test_project_stats_empty_project` — unknown project renders cleanly with zeroed stats (no 500).

`pytest tests/ -q` shows no new failures (the ~6 known-unrelated `sdk/python/tests` failures are out of scope).

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZnLF4dWe5WnQpsixziUaQ
