### PR TITLE
fix(matcher): eliminate shared mutable state race in SemanticDataMatcher (#105)

### DIFF
--- a/src/core/context_engine.py
+++ b/src/core/context_engine.py
@@ -558,25 +558,15 @@ class ContextEngine:
         """
         print(f"[ContextEngine] Ad-hoc query for project {project_id}: '{query}'")
 
-        # Use semantic matcher with temporary overrides
-        original_max = self.semantic_matcher.max_matches
-        original_threshold = self.semantic_matcher.threshold
-        self.semantic_matcher.max_matches = top_k
-        if threshold is not None:
-            self.semantic_matcher.threshold = threshold
+        # Pass per-request top_k/threshold through instead of mutating the shared
+        # matcher, so concurrent ad-hoc queries can't corrupt each other (#105).
+        matches = await self.semantic_matcher.match_agent_needs(
+            project_id, [query], top_k=top_k, threshold=threshold
+        )
 
-        try:
-            # Match the query as if it were a single agent need
-            matches = await self.semantic_matcher.match_agent_needs(project_id, [query])
+        # Extract matches for the query
+        results = matches.get(query, [])
 
-            # Extract matches for the query
-            results = matches.get(query, [])
+        print(f"[ContextEngine] Found {len(results)} matches for query")
 
-            print(f"[ContextEngine] Found {len(results)} matches for query")
-
-            return results
-
-        finally:
-            # Restore original values
-            self.semantic_matcher.max_matches = original_max
-            self.semantic_matcher.threshold = original_threshold
+        return results

--- a/src/core/matcher.py
+++ b/src/core/matcher.py
@@ -35,9 +35,7 @@ class HybridMatcher:
         top_k: int | None = None,
         threshold: float | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
-        # Pass per-request parameters straight through. The matcher no longer
-        # holds mutable per-request state, so nothing needs save/restore here and
-        # concurrent calls stay isolated (#105).
+        # Pass per-request params straight through; nothing is mutated on the matcher (#105).
         return await self.semantic_matcher.match_agent_needs(
             project_id, needs, top_k=top_k, threshold=threshold
         )

--- a/src/core/matcher.py
+++ b/src/core/matcher.py
@@ -35,15 +35,9 @@ class HybridMatcher:
         top_k: int | None = None,
         threshold: float | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
-        sm = self.semantic_matcher
-        if top_k is None and threshold is None:
-            return await sm.match_agent_needs(project_id, needs)
-        old_max, old_thr = sm.max_matches, sm.threshold
-        try:
-            if top_k is not None:
-                sm.max_matches = top_k
-            if threshold is not None:
-                sm.threshold = threshold
-            return await sm.match_agent_needs(project_id, needs)
-        finally:
-            sm.max_matches, sm.threshold = old_max, old_thr
+        # Pass per-request parameters straight through. The matcher no longer
+        # holds mutable per-request state, so nothing needs save/restore here and
+        # concurrent calls stay isolated (#105).
+        return await self.semantic_matcher.match_agent_needs(
+            project_id, needs, top_k=top_k, threshold=threshold
+        )

--- a/src/core/semantic_matcher.py
+++ b/src/core/semantic_matcher.py
@@ -221,12 +221,8 @@ class SemanticDataMatcher:
         Args:
             project_id: Project identifier
             needs: List of semantic needs (natural language)
-            top_k: Per-request maximum matches to return per need. Defaults to
-                the instance ``max_matches``. Passed as an argument (rather than
-                mutated on the instance) so concurrent requests never read each
-                other's value.
-            threshold: Per-request minimum similarity to match (0-1). Defaults to
-                the instance ``threshold``. Also per-request for the same reason.
+            top_k: Per-request max matches per need; defaults to the instance value.
+            threshold: Per-request min similarity (0-1); defaults to the instance value.
 
         Returns:
             Dict mapping needs to matched data sources:
@@ -237,9 +233,6 @@ class SemanticDataMatcher:
                 ]
             }
         """
-        # Resolve per-request parameters locally. Reading these into locals keeps
-        # all shared mutable state off the hot path: nothing on `self` is mutated,
-        # so interleaved concurrent calls can't corrupt each other (#105).
         effective_max = top_k if top_k is not None else self.max_matches
         effective_threshold = (
             threshold if threshold is not None else self.threshold

--- a/src/core/semantic_matcher.py
+++ b/src/core/semantic_matcher.py
@@ -206,7 +206,11 @@ class SemanticDataMatcher:
         )
 
     async def match_agent_needs(
-        self, project_id: str, needs: List[str]
+        self,
+        project_id: str,
+        needs: List[str],
+        top_k: Optional[int] = None,
+        threshold: Optional[float] = None,
     ) -> Dict[str, List[Dict[str, Any]]]:
         """
         Match agent semantic needs to available data.
@@ -217,6 +221,12 @@ class SemanticDataMatcher:
         Args:
             project_id: Project identifier
             needs: List of semantic needs (natural language)
+            top_k: Per-request maximum matches to return per need. Defaults to
+                the instance ``max_matches``. Passed as an argument (rather than
+                mutated on the instance) so concurrent requests never read each
+                other's value.
+            threshold: Per-request minimum similarity to match (0-1). Defaults to
+                the instance ``threshold``. Also per-request for the same reason.
 
         Returns:
             Dict mapping needs to matched data sources:
@@ -227,6 +237,14 @@ class SemanticDataMatcher:
                 ]
             }
         """
+        # Resolve per-request parameters locally. Reading these into locals keeps
+        # all shared mutable state off the hot path: nothing on `self` is mutated,
+        # so interleaved concurrent calls can't corrupt each other (#105).
+        effective_max = top_k if top_k is not None else self.max_matches
+        effective_threshold = (
+            threshold if threshold is not None else self.threshold
+        )
+
         matches = {}
 
         for need in needs:
@@ -238,7 +256,7 @@ class SemanticDataMatcher:
                     fused = await self.hybrid_search.search(
                         project_id=project_id,
                         query=need,
-                        top_k=self.max_matches * 2,
+                        top_k=effective_max * 2,
                     )
 
                     candidates = []
@@ -260,7 +278,7 @@ class SemanticDataMatcher:
                                     "description": embedding_row.description,
                                 })
 
-                    matches[need] = candidates[: self.max_matches]
+                    matches[need] = candidates[:effective_max]
 
                     logger.debug(
                         "Hybrid search matches",
@@ -286,7 +304,7 @@ class SemanticDataMatcher:
                     )
                     .where(Embedding.project_id == project_id)
                     .order_by(Embedding.embedding.cosine_distance(need_embedding.tolist()))
-                    .limit(self.max_matches * 2)
+                    .limit(effective_max * 2)
                 )
 
                 candidates = []
@@ -294,7 +312,7 @@ class SemanticDataMatcher:
                     embedding_obj = row[0]
                     similarity = float(row[1])
 
-                    if similarity >= self.threshold:
+                    if similarity >= effective_threshold:
                         candidates.append({
                             "data_key": embedding_obj.node_key,
                             "similarity": similarity,
@@ -304,7 +322,7 @@ class SemanticDataMatcher:
 
                 # Sort and limit
                 candidates.sort(key=lambda x: x["similarity"], reverse=True)
-                matches[need] = candidates[: self.max_matches]
+                matches[need] = candidates[:effective_max]
 
                 if matches[need]:
                     logger.debug(
@@ -317,7 +335,7 @@ class SemanticDataMatcher:
                     logger.debug(
                         "No matches found",
                         need=need,
-                        threshold=self.threshold,
+                        threshold=effective_threshold,
                     )
 
         return matches

--- a/src/web/routes.py
+++ b/src/web/routes.py
@@ -2,6 +2,7 @@
 
 import json
 import asyncio
+import tiktoken
 from fastapi import APIRouter, Request, Form, Query
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
@@ -83,7 +84,6 @@ async def execute_query(
         matches = truncated.get(query, [])
 
     # Calculate token counts
-    import tiktoken
     try:
         enc = tiktoken.get_encoding("cl100k_base")
     except:

--- a/src/web/routes.py
+++ b/src/web/routes.py
@@ -66,15 +66,14 @@ async def execute_query(
 
     # Pass the per-request threshold through instead of mutating the shared
     # matcher singleton, so concurrent /query requests stay isolated (#105).
-    # Over-fetch candidates so the token-limit truncation below has room to work.
     matches = await engine.query_project_data(
         project_id=project_id,
         query=query,
-        top_k=top_k * 3,
+        top_k=top_k,
         threshold=threshold,
     )
 
-    # Limit to top_k (candidates already threshold-filtered by the matcher)
+    # Defensive cap (the matcher already limits to top_k)
     matches = matches[:top_k]
 
     # Apply token limit truncation if specified

--- a/src/web/routes.py
+++ b/src/web/routes.py
@@ -64,103 +64,95 @@ async def execute_query(
     """Execute a semantic query and return results"""
     engine = request.app.state.context_engine
 
-    # Override the semantic matcher's threshold temporarily
-    original_threshold = engine.semantic_matcher.threshold
-    engine.semantic_matcher.threshold = threshold
+    # Pass the per-request threshold through instead of mutating the shared
+    # matcher singleton, so concurrent /query requests stay isolated (#105).
+    # Over-fetch candidates so the token-limit truncation below has room to work.
+    matches = await engine.query_project_data(
+        project_id=project_id,
+        query=query,
+        top_k=top_k * 3,
+        threshold=threshold,
+    )
 
+    # Limit to top_k (candidates already threshold-filtered by the matcher)
+    matches = matches[:top_k]
+
+    # Apply token limit truncation if specified
+    if max_tokens and matches:
+        matches_dict = {query: matches}
+        truncated = engine._truncate_matches(matches_dict, max_tokens)
+        matches = truncated.get(query, [])
+
+    # Calculate token counts
+    import tiktoken
     try:
-        # Execute query (get more candidates for threshold filtering)
-        matches = await engine.query_project_data(
-            project_id=project_id,
-            query=query,
-            top_k=top_k * 3
-        )
+        enc = tiktoken.get_encoding("cl100k_base")
+    except:
+        enc = None
 
-        # Filter by threshold (scores are normalized to 0-1 range)
-        matches = [m for m in matches if m["similarity"] >= threshold]
+    # Enhance matches with metadata
+    enhanced_matches = []
+    total_tokens = 0
 
-        # Limit to top_k after filtering
-        matches = matches[:top_k]
-
-        # Apply token limit truncation if specified
-        if max_tokens and matches:
-            matches_dict = {query: matches}
-            truncated = engine._truncate_matches(matches_dict, max_tokens)
-            matches = truncated.get(query, [])
-
-        # Calculate token counts
-        import tiktoken
+    for match in matches:
+        # Generate both JSON and TOON formats
+        data_json = json.dumps(match["data"], indent=2)
         try:
-            enc = tiktoken.get_encoding("cl100k_base")
-        except:
-            enc = None
+            data_toon = toon.encode(match["data"])
+        except NotImplementedError:
+            # TOON encoder not yet available, use JSON as fallback
+            data_toon = data_json
 
-        # Enhance matches with metadata
-        enhanced_matches = []
-        total_tokens = 0
-
-        for match in matches:
-            # Generate both JSON and TOON formats
-            data_json = json.dumps(match["data"], indent=2)
+        # Calculate token counts for both formats
+        json_tokens = 0
+        toon_tokens = 0
+        if enc:
             try:
-                data_toon = toon.encode(match["data"])
-            except NotImplementedError:
-                # TOON encoder not yet available, use JSON as fallback
-                data_toon = data_json
+                json_tokens = len(enc.encode(data_json))
+                toon_tokens = len(enc.encode(data_toon))
+                total_tokens += toon_tokens  # Use TOON tokens for total
+            except:
+                pass
 
-            # Calculate token counts for both formats
-            json_tokens = 0
-            toon_tokens = 0
-            if enc:
-                try:
-                    json_tokens = len(enc.encode(data_json))
-                    toon_tokens = len(enc.encode(data_toon))
-                    total_tokens += toon_tokens  # Use TOON tokens for total
-                except:
-                    pass
+        # Calculate token savings
+        token_savings = 0
+        savings_percent = 0
+        if json_tokens > 0 and toon_tokens > 0:
+            token_savings = json_tokens - toon_tokens
+            savings_percent = round((token_savings / json_tokens) * 100, 1)
 
-            # Calculate token savings
-            token_savings = 0
-            savings_percent = 0
-            if json_tokens > 0 and toon_tokens > 0:
-                token_savings = json_tokens - toon_tokens
-                savings_percent = round((token_savings / json_tokens) * 100, 1)
+        # No preview truncation - will be handled by CSS scrolling
+        preview = data_toon
 
-            # No preview truncation - will be handled by CSS scrolling
-            preview = data_toon
+        enhanced_matches.append({
+            "data_key": match["data_key"],
+            "similarity": match["similarity"],
+            "similarity_percent": round(match["similarity"] * 100, 1),
+            "data": match["data"],
+            "data_json": data_json,
+            "data_toon": data_toon,
+            "description": match.get("description", ""),
+            "token_count": toon_tokens,
+            "json_tokens": json_tokens,
+            "toon_tokens": toon_tokens,
+            "token_savings": token_savings,
+            "savings_percent": savings_percent,
+            "preview": preview
+        })
 
-            enhanced_matches.append({
-                "data_key": match["data_key"],
-                "similarity": match["similarity"],
-                "similarity_percent": round(match["similarity"] * 100, 1),
-                "data": match["data"],
-                "data_json": data_json,
-                "data_toon": data_toon,
-                "description": match.get("description", ""),
-                "token_count": toon_tokens,
-                "json_tokens": json_tokens,
-                "toon_tokens": toon_tokens,
-                "token_savings": token_savings,
-                "savings_percent": savings_percent,
-                "preview": preview
-            })
-
-        return templates.TemplateResponse(
-            "query_results.html",
-            {
-                "request": request,
-                "query": query,
-                "project_id": project_id,
-                "matches": enhanced_matches,
-                "total_matches": len(enhanced_matches),
-                "total_tokens": total_tokens,
-                "threshold": threshold,
-                "top_k": top_k
-            }
-        )
-    finally:
-        # Restore original threshold
-        engine.semantic_matcher.threshold = original_threshold
+    return templates.TemplateResponse(
+        "query_results.html",
+        {
+            "request": request,
+            "query": query,
+            "project_id": project_id,
+            "matches": enhanced_matches,
+            "total_matches": len(enhanced_matches),
+            "total_tokens": total_tokens,
+            "threshold": threshold,
+            "top_k": top_k
+        }
+    )
 
 
 @router.get("/projects/{project_id}/stats", response_class=HTMLResponse)

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -6,8 +6,10 @@ class _FakeSemanticMatcher:
     def __init__(self):
         self.calls = []
 
+    # top_k/threshold are accepted so match() can call us, but not recorded here;
+    # pass-through is asserted by test_matcher_threads_top_k_and_threshold_per_request.
     async def match_agent_needs(self, project_id, needs, top_k=None, threshold=None):
-        self.calls.append((project_id, tuple(needs), top_k, threshold))
+        self.calls.append((project_id, tuple(needs)))
         return {n: [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}] for n in needs}
 
 
@@ -17,15 +19,22 @@ async def test_hybrid_matcher_delegates_and_returns_bundle_shape():
     matcher = HybridMatcher(sem)
     result = await matcher.match("p1", ["auth config"], metadata={"format": "json"})
     assert result == {"auth config": [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}]}
-    # metadata is accepted but not passed through (seam only); top_k/threshold
-    # default to None and are threaded to the matcher as per-request args.
-    assert sem.calls == [("p1", ("auth config",), None, None)]
+    assert sem.calls == [("p1", ("auth config",))]  # metadata is accepted but not passed through (seam only)
 
 
 @pytest.mark.asyncio
 async def test_matcher_threads_top_k_and_threshold_per_request():
     """top_k/threshold are passed through as arguments, not mutated on state."""
-    sem = _FakeSemanticMatcher()
+
+    class _RecordingSemanticMatcher:
+        def __init__(self):
+            self.calls = []
+
+        async def match_agent_needs(self, project_id, needs, top_k=None, threshold=None):
+            self.calls.append((project_id, tuple(needs), top_k, threshold))
+            return {n: [] for n in needs}
+
+    sem = _RecordingSemanticMatcher()
     matcher = HybridMatcher(sem)
     await matcher.match("p1", ["auth"], top_k=3, threshold=0.7)
     assert sem.calls == [("p1", ("auth",), 3, 0.7)]
@@ -37,7 +46,7 @@ async def test_matcher_handles_multiple_needs():
     matcher = HybridMatcher(sem)
     result = await matcher.match("p1", ["a", "b"])
     # delegate called exactly once with both needs
-    assert sem.calls == [("p1", ("a", "b"), None, None)]
+    assert sem.calls == [("p1", ("a", "b"))]
     # result has an entry for each need
     assert set(result.keys()) == {"a", "b"}
     assert result["a"] == [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}]
@@ -50,7 +59,7 @@ async def test_matcher_empty_needs_returns_empty():
     matcher = HybridMatcher(sem)
     result = await matcher.match("p1", [])
     # delegate is still called (HybridMatcher is a thin seam; it delegates unconditionally)
-    assert sem.calls == [("p1", (), None, None)]
+    assert sem.calls == [("p1", ())]
     # with no needs, the returned dict is empty
     assert result == {}
 
@@ -64,7 +73,7 @@ async def test_matcher_passes_through_empty_matches():
             self.calls = []
 
         async def match_agent_needs(self, project_id, needs, top_k=None, threshold=None):
-            self.calls.append((project_id, tuple(needs), top_k, threshold))
+            self.calls.append((project_id, tuple(needs)))
             # each need maps to an empty list — no matches found
             return {n: [] for n in needs}
 
@@ -72,4 +81,4 @@ async def test_matcher_passes_through_empty_matches():
     matcher = HybridMatcher(sem)
     result = await matcher.match("p1", ["x", "y"])
     assert result == {"x": [], "y": []}
-    assert sem.calls == [("p1", ("x", "y"), None, None)]
+    assert sem.calls == [("p1", ("x", "y"))]

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -6,8 +6,8 @@ class _FakeSemanticMatcher:
     def __init__(self):
         self.calls = []
 
-    async def match_agent_needs(self, project_id, needs):
-        self.calls.append((project_id, tuple(needs)))
+    async def match_agent_needs(self, project_id, needs, top_k=None, threshold=None):
+        self.calls.append((project_id, tuple(needs), top_k, threshold))
         return {n: [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}] for n in needs}
 
 
@@ -17,7 +17,18 @@ async def test_hybrid_matcher_delegates_and_returns_bundle_shape():
     matcher = HybridMatcher(sem)
     result = await matcher.match("p1", ["auth config"], metadata={"format": "json"})
     assert result == {"auth config": [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}]}
-    assert sem.calls == [("p1", ("auth config",))]  # metadata is accepted but not passed through (seam only)
+    # metadata is accepted but not passed through (seam only); top_k/threshold
+    # default to None and are threaded to the matcher as per-request args.
+    assert sem.calls == [("p1", ("auth config",), None, None)]
+
+
+@pytest.mark.asyncio
+async def test_matcher_threads_top_k_and_threshold_per_request():
+    """top_k/threshold are passed through as arguments, not mutated on state."""
+    sem = _FakeSemanticMatcher()
+    matcher = HybridMatcher(sem)
+    await matcher.match("p1", ["auth"], top_k=3, threshold=0.7)
+    assert sem.calls == [("p1", ("auth",), 3, 0.7)]
 
 
 @pytest.mark.asyncio
@@ -26,7 +37,7 @@ async def test_matcher_handles_multiple_needs():
     matcher = HybridMatcher(sem)
     result = await matcher.match("p1", ["a", "b"])
     # delegate called exactly once with both needs
-    assert sem.calls == [("p1", ("a", "b"))]
+    assert sem.calls == [("p1", ("a", "b"), None, None)]
     # result has an entry for each need
     assert set(result.keys()) == {"a", "b"}
     assert result["a"] == [{"data_key": "k", "similarity": 0.8, "data": {}, "description": None}]
@@ -39,7 +50,7 @@ async def test_matcher_empty_needs_returns_empty():
     matcher = HybridMatcher(sem)
     result = await matcher.match("p1", [])
     # delegate is still called (HybridMatcher is a thin seam; it delegates unconditionally)
-    assert sem.calls == [("p1", ())]
+    assert sem.calls == [("p1", (), None, None)]
     # with no needs, the returned dict is empty
     assert result == {}
 
@@ -52,8 +63,8 @@ async def test_matcher_passes_through_empty_matches():
         def __init__(self):
             self.calls = []
 
-        async def match_agent_needs(self, project_id, needs):
-            self.calls.append((project_id, tuple(needs)))
+        async def match_agent_needs(self, project_id, needs, top_k=None, threshold=None):
+            self.calls.append((project_id, tuple(needs), top_k, threshold))
             # each need maps to an empty list — no matches found
             return {n: [] for n in needs}
 
@@ -61,4 +72,4 @@ async def test_matcher_passes_through_empty_matches():
     matcher = HybridMatcher(sem)
     result = await matcher.match("p1", ["x", "y"])
     assert result == {"x": [], "y": []}
-    assert sem.calls == [("p1", ("x", "y"))]
+    assert sem.calls == [("p1", ("x", "y"), None, None)]

--- a/tests/test_semantic_matcher.py
+++ b/tests/test_semantic_matcher.py
@@ -1,5 +1,7 @@
 """Tests for semantic data matching with PostgreSQL/pgvector"""
 
+import asyncio
+
 import pytest
 import pytest_asyncio
 import numpy as np
@@ -216,6 +218,117 @@ class TestSemanticDataMatcher:
         # Should still have one entry (updated, not duplicated)
         config_count = keys.count("config")
         assert config_count == 1
+
+
+class TestSemanticMatcherConcurrency:
+    """Concurrent requests must not clobber each other's per-request parameters.
+
+    Regression test for #105: `match_agent_needs` previously read `top_k`/
+    `threshold` from mutable instance attributes on a shared singleton, which
+    callers save/mutated/restored around ``await`` points. Under concurrency the
+    interleaved queries read each other's values, silently returning results with
+    the wrong match count or threshold. The fix threads these as per-call
+    arguments so nothing shared is mutated.
+    """
+
+    @pytest_asyncio.fixture
+    async def matcher(self, db):
+        """Matcher with a mocked model so every text embeds identically.
+
+        With identical embeddings and threshold 0, every registered item is a
+        match, so a call with ``top_k=k`` must return exactly ``min(k, N)``
+        results regardless of what any concurrent call requests.
+        """
+        with patch("src.core.semantic_matcher.SentenceTransformer") as mock_model_cls:
+            mock_model = Mock()
+            mock_model.encode.return_value = np.ones(384).astype(np.float32)
+            mock_model_cls.return_value = mock_model
+
+            matcher = SemanticDataMatcher(
+                db=db,
+                model_name="all-MiniLM-L6-v2",
+                similarity_threshold=0.5,
+                max_matches=10,
+            )
+            await matcher.initialize_index()
+            return matcher
+
+    @pytest.mark.asyncio
+    async def test_concurrent_top_k_do_not_cross_contaminate(self, matcher):
+        """Interleaved calls with different top_k each get their own count."""
+        n_items = 8
+        for i in range(n_items):
+            await matcher.register_data("projc", f"item_{i}", {"idx": i})
+
+        need = "anything"
+
+        async def query(k: int) -> int:
+            result = await matcher.match_agent_needs(
+                "projc", [need], top_k=k, threshold=0.0
+            )
+            return len(result[need])
+
+        # Many interleaved calls, each requesting a different number of matches.
+        # If per-request state leaked through a shared attribute, some calls would
+        # return another call's count.
+        ks = [(i % n_items) + 1 for i in range(60)]
+        counts = await asyncio.gather(*(query(k) for k in ks))
+
+        for requested, got in zip(ks, counts):
+            assert got == requested, (
+                f"requested top_k={requested} but got {got} matches; "
+                "concurrent requests cross-contaminated shared state"
+            )
+
+    @pytest.mark.asyncio
+    async def test_concurrent_threshold_do_not_cross_contaminate(self, matcher):
+        """A strict-threshold call must not be relaxed by a concurrent lenient one.
+
+        All items embed identically to the query, so similarity is 1.0 for every
+        item. A threshold of 1.5 excludes everything; a threshold of 0.0 includes
+        everything. Interleaving the two must keep the strict call at zero.
+        """
+        for i in range(5):
+            await matcher.register_data("projt", f"item_{i}", {"idx": i})
+
+        need = "anything"
+
+        async def strict() -> int:
+            result = await matcher.match_agent_needs(
+                "projt", [need], top_k=10, threshold=1.5
+            )
+            return len(result[need])
+
+        async def lenient() -> int:
+            result = await matcher.match_agent_needs(
+                "projt", [need], top_k=10, threshold=0.0
+            )
+            return len(result[need])
+
+        tasks = []
+        for _ in range(20):
+            tasks.append(strict())
+            tasks.append(lenient())
+        results = await asyncio.gather(*tasks)
+
+        strict_counts = results[0::2]
+        lenient_counts = results[1::2]
+        assert all(c == 0 for c in strict_counts), (
+            f"strict threshold leaked matches: {strict_counts}"
+        )
+        assert all(c == 5 for c in lenient_counts), (
+            f"lenient threshold lost matches: {lenient_counts}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_match_agent_needs_does_not_mutate_instance_state(self, matcher):
+        """Passing per-call top_k/threshold must leave the instance defaults intact."""
+        await matcher.register_data("projm", "item", {"idx": 0})
+
+        await matcher.match_agent_needs("projm", ["x"], top_k=1, threshold=0.99)
+
+        assert matcher.max_matches == 10
+        assert matcher.threshold == 0.5
 
 
 class TestSemanticMatcherWithRealEmbeddings:


### PR DESCRIPTION
Closes #105

## Problem

`SemanticDataMatcher` is a singleton on the `ContextEngine`, but three call sites configured per-request `top_k`/`threshold` by **saving, mutating, and restoring the instance attributes** (`self.max_matches` / `self.threshold`) around `await` points:

- `HybridMatcher.match` (`src/core/matcher.py`)
- `ContextEngine.query_project_data` (`src/core/context_engine.py`)
- the `/query` web route `execute_query` (`src/web/routes.py`)

Because the mutation straddled `await`s, concurrent `contex_query` / `/sandbox/query` requests interleaved and read **each other's** values, silently returning results with the wrong match count or threshold.

## Fix (stateless, not a lock)

Threaded `top_k`/`threshold` through as **per-request arguments** instead of mutating shared state:

- `match_agent_needs(project_id, needs, top_k=None, threshold=None)` now resolves the effective values into locals (`effective_max`, `effective_threshold`), defaulting to the instance values. Nothing on `self` is mutated per request.
- All three call sites now pass the values through and drop their save/mutate/restore dances. The `/query` route also drops its now-redundant Python-side threshold filter (the matcher applies the threshold directly).

Chose stateless over a lock: eliminating the shared mutation removes the race entirely and keeps concurrent matching fully parallel (no serialization on a lock). This is exactly the direction the issue recommended.

No schema change; no migration.

## Tests

- New `TestSemanticMatcherConcurrency` in `tests/test_semantic_matcher.py` fires many interleaved `match_agent_needs` calls with differing `top_k`/`threshold` via `asyncio.gather` and asserts each call gets exactly its own requested count / threshold behavior, plus that instance defaults are never mutated. These fail against the old code and pass with the fix.
- New `test_matcher_threads_top_k_and_threshold_per_request` and updated fakes in `tests/test_matcher.py` assert the params are passed through the seam.

`pytest tests/ -q`: **381 passed** (full `tests/` tree green; the ~6 known-unrelated `sdk/python/tests` failures are out of scope and were not run here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZnLF4dWe5WnQpsixziUaQ
