### PR TITLE
fix(event-store): atomic per-project event sequence assignment (#104)

### DIFF
--- a/alembic/versions/006_event_sequence_counter.py
+++ b/alembic/versions/006_event_sequence_counter.py
@@ -1,0 +1,57 @@
+"""Add per-project event sequence counter for atomic sequence assignment
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-09-04 00:00:00.000000
+
+Fixes #104: sequence assignment previously used SELECT MAX(sequence)+1 then
+INSERT with no locking, so concurrent publishes to the same project computed the
+same sequence and the loser violated the (project_id, sequence) unique
+constraint -> IntegrityError -> 500 (with the losing write lost).
+
+This introduces a dedicated per-project counter table. The event store now bumps
+the counter with a single atomic
+
+    INSERT INTO event_sequence_counters (project_id, last_sequence)
+    VALUES (:project_id, 1)
+    ON CONFLICT (project_id)
+    DO UPDATE SET last_sequence = event_sequence_counters.last_sequence + 1
+    RETURNING last_sequence
+
+statement, which takes a row lock on the project's counter row and serialises
+concurrent publishes to that project while keeping sequences per-project,
+monotonic, and starting from 1. Existing events are backfilled so new sequences
+continue from each project's current max.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '006'
+down_revision: Union[str, None] = '005'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "event_sequence_counters",
+        sa.Column("project_id", sa.String(length=255), primary_key=True),
+        sa.Column("last_sequence", sa.BigInteger(), nullable=False, server_default="0"),
+    )
+    # Backfill from any events that already exist so new sequences continue from
+    # each project's current max rather than restarting at 1.
+    op.execute(
+        """
+        INSERT INTO event_sequence_counters (project_id, last_sequence)
+        SELECT project_id, MAX(sequence)
+        FROM events
+        GROUP BY project_id
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("event_sequence_counters")

--- a/src/core/db_models.py
+++ b/src/core/db_models.py
@@ -214,6 +214,25 @@ class Event(Base):
     )
 
 
+class EventSequenceCounter(Base):
+    """Per-project event sequence counter.
+
+    Backs atomic, race-free sequence assignment for the event log (#104). The
+    event store bumps a project's counter with a single
+    ``INSERT ... ON CONFLICT (project_id) DO UPDATE ... RETURNING`` statement,
+    which row-locks the counter and serialises concurrent publishes to the same
+    project while keeping sequences per-project, monotonic, and starting from 1.
+    Kept in agreement with alembic migration 006 (which is the schema source).
+    """
+
+    __tablename__ = "event_sequence_counters"
+
+    project_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    last_sequence: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, server_default="0"
+    )
+
+
 class Snapshot(Base):
     """Snapshot model - project state snapshots."""
 

--- a/src/core/event_store.py
+++ b/src/core/event_store.py
@@ -53,13 +53,6 @@ class EventStore:
         """
         actor = actor or {}
         async with self.db.session() as session:
-            # Atomically claim the next per-project sequence. A single
-            # INSERT ... ON CONFLICT (project_id) DO UPDATE ... RETURNING both
-            # row-locks the project's counter and returns the bumped value, so
-            # concurrent publishes to the same project are serialised and can no
-            # longer compute a duplicate sequence (#104). The old
-            # SELECT MAX(sequence)+1 then INSERT pattern raced under READ
-            # COMMITTED and 500'd on the (project_id, sequence) unique index.
             counter_stmt = (
                 pg_insert(EventSequenceCounter)
                 .values(project_id=project_id, last_sequence=1)

--- a/src/core/event_store.py
+++ b/src/core/event_store.py
@@ -3,10 +3,11 @@
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import func, select, delete
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.database import DatabaseManager
-from src.core.db_models import Event
+from src.core.db_models import Event, EventSequenceCounter
 from src.core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -52,11 +53,25 @@ class EventStore:
         """
         actor = actor or {}
         async with self.db.session() as session:
-            result = await session.execute(
-                select(func.coalesce(func.max(Event.sequence), 0) + 1)
-                .where(Event.project_id == project_id)
+            # Atomically claim the next per-project sequence. A single
+            # INSERT ... ON CONFLICT (project_id) DO UPDATE ... RETURNING both
+            # row-locks the project's counter and returns the bumped value, so
+            # concurrent publishes to the same project are serialised and can no
+            # longer compute a duplicate sequence (#104). The old
+            # SELECT MAX(sequence)+1 then INSERT pattern raced under READ
+            # COMMITTED and 500'd on the (project_id, sequence) unique index.
+            counter_stmt = (
+                pg_insert(EventSequenceCounter)
+                .values(project_id=project_id, last_sequence=1)
+                .on_conflict_do_update(
+                    index_elements=[EventSequenceCounter.project_id],
+                    set_={
+                        "last_sequence": EventSequenceCounter.last_sequence + 1,
+                    },
+                )
+                .returning(EventSequenceCounter.last_sequence)
             )
-            sequence = result.scalar()
+            sequence = (await session.execute(counter_stmt)).scalar_one()
 
             event = Event(
                 project_id=project_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,7 @@ async def db() -> AsyncGenerator[DatabaseManager, None]:
                     await session.execute(text("DELETE FROM embeddings"))
                     await session.execute(text("DELETE FROM snapshots"))
                     await session.execute(text("DELETE FROM events"))
+                    await session.execute(text("DELETE FROM event_sequence_counters"))
                     await session.execute(text("DELETE FROM service_account_keys"))
                     await session.execute(text("DELETE FROM service_accounts"))
                     await session.execute(text("DELETE FROM api_key_roles"))

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -1,5 +1,7 @@
 """Tests for event store with PostgreSQL"""
 
+import asyncio
+
 import pytest
 import pytest_asyncio
 from sqlalchemy import select
@@ -221,6 +223,46 @@ async def test_append_event_persists_provenance(db):
         assert row.actor_id == "key-abc"
         assert row.actor_type == "api_key"
         assert row.actor_ip == "10.0.0.9"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_appends_are_unique_and_monotonic(db):
+    """Concurrent publishes to the same project must not race on the sequence.
+
+    Regression for #104: the previous SELECT MAX(sequence)+1 then INSERT pattern
+    let two concurrent transactions compute the same sequence, so the second
+    INSERT violated the (project_id, sequence) unique constraint and 500'd, with
+    the losing write lost. Fire many appends concurrently and assert every one
+    succeeds, sequences are unique, and they form the contiguous run 1..N.
+    """
+    store = EventStore(db)
+    n = 50
+
+    # No append may raise: gather propagates the first IntegrityError (the 500 the
+    # racy MAX+1/INSERT pattern produced). A single burst can miss the race window,
+    # so run a few rounds to make the assertion reliable.
+    total = 0
+    for _ in range(3):
+        results = await asyncio.gather(
+            *(
+                store.append_event("proj-race", f"event{i}", {"i": i})
+                for i in range(n)
+            )
+        )
+        assert len(results) == n
+        total += n
+
+    # Everything that landed in the table forms the contiguous, monotonic run
+    # 1..total (per-project, from 1) with no duplicates and no gaps.
+    async with db.session() as session:
+        rows = (
+            await session.execute(
+                select(Event.sequence)
+                .where(Event.project_id == "proj-race")
+                .order_by(Event.sequence.asc())
+            )
+        ).scalars().all()
+    assert rows == list(range(1, total + 1))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #104.

Event sequence assignment in `src/core/event_store.py` used `SELECT MAX(sequence)+1` then `INSERT` with no locking. Under READ COMMITTED, two concurrent publishes to the same project computed the **same** sequence; the losing `INSERT` violated the `(project_id, sequence)` unique index → `IntegrityError` → 500, and that write was lost. Unauthenticated concurrency was enough to trigger it.

## Fix

A dedicated **per-project counter table** (`event_sequence_counters`) plus a single atomic claim per publish:

```sql
INSERT INTO event_sequence_counters (project_id, last_sequence)
VALUES (:project_id, 1)
ON CONFLICT (project_id)
DO UPDATE SET last_sequence = event_sequence_counters.last_sequence + 1
RETURNING last_sequence
```

This row-locks the project's counter and returns the bumped value in one round trip, serialising concurrent publishes **to the same project** while leaving different projects contention-free. Sequences stay per-project, monotonic, and start at 1. No more `MAX` scan.

### Why this approach
- A single global `SEQUENCE` would be global/gappy and break the per-project "starts at 1" invariant the code and tests rely on.
- An advisory lock works but needs no schema change; a counter table is the cleanest per-project, monotonic-from-1, atomic option and is what the issue itself suggests (`SELECT ... FOR UPDATE on a per-project counter`). The `ON CONFLICT ... RETURNING` form does the row-lock + read + bump in one statement.

## Changes
- **Migration 006** (`alembic/versions/006_event_sequence_counter.py`), chained from **005** — creates `event_sequence_counters`, backfills `MAX(sequence)` per existing project, drops on downgrade. Schema source remains Alembic.
- `db_models.py` gains `EventSequenceCounter` (query-building parity).
- `event_store.append_event` now claims sequences atomically.
- Test cleanup fixture clears the new counter table between tests.

## Tests
- New regression test `test_concurrent_appends_are_unique_and_monotonic` fires 50 concurrent `append_event` calls per round across several rounds and asserts every publish succeeds and sequences are unique, monotonic, and gap-free (`1..N`). Verified RED against the old code, GREEN with the fix.
- `pytest tests/ -q` → **378 passed**, no new failures. Migration verified for downgrade/upgrade round-trip and single head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZnLF4dWe5WnQpsixziUaQ