### PR TITLE
Tier 0 ownership enforcement: tenant/project IDOR checks (#42/#43/#54/#55/#73)

### DIFF
--- a/docs/superpowers/plans/2026-09-07-tier0-ownership-batch1.md
+++ b/docs/superpowers/plans/2026-09-07-tier0-ownership-batch1.md
@@ -1,0 +1,242 @@
+# Tier 0 Ownership Checks — Batch 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Close the tenant/project IDOR gaps that the Wave D `Identity` foundation now makes expressible — API-key tenant-scoping (#43), cross-project ownership on data routes (#54), admin-cleanup ownership (#55), the `/sandbox/subscribe` project-scope check — and remove the dead `require_admin_permission` guard (#39 remnant).
+
+**Architecture:** A single `check_project_access(identity, project_id, tenant_mgr, *, create_if_absent)` helper enforces project→tenant ownership, gated so it is a **no-op unless multi-tenancy is on AND the caller carries a tenant** (single-tenant/demo unaffected). Routes that need it take `identity: Identity = Depends(require(P))` (instead of a bare `dependencies=[...]`) and call the helper. API-key routes pass `identity.tenant_id` to the already-tenant-aware service functions.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy async, Postgres+pgvector, pytest (live `pgvector/pgvector:pg16` + Redis).
+
+**Spec basis:** Wave D foundation (`docs/superpowers/specs/2026-09-05-fail-closed-authz-foundation-design.md`, §Non-goals lists these as fast-follows). Ownership-model recon: project→tenant lives in `TenantProject`, resolvable via `TenantManager.get_project_tenant()`; `APIKey.tenant_id` exists; there is no Projects table (project_id is a free-form string).
+
+## Global Constraints
+
+- **No DB migration.** Alembic head stays `006`. Batch 2 (#42/#73 subscriptions) is a separate plan.
+- **Ownership check is gated:** no-op when `not MULTI_TENANT_ENABLED` OR `identity.tenant_id is None`. This preserves single-tenant and auth-off/demo behavior exactly.
+- **Decisions locked (Rob, 2026-09-07):** (1) ownership active only when multi-tenant + identity has a tenant; (2) first publish to an unowned project auto-binds it to the caller's tenant; reads to an unowned project are denied.
+- **Commit structure:** discrete single-purpose commits, each CI-green (TDD: test commit may precede impl). Work on branch `worktree-tier0-ownership`; never push or open the PR until asked.
+- **Code style (Rob):** imports top-level (no inline); no meta/historical comments; concise docstrings; generic client-facing error text ("Forbidden"), never leak internals.
+- **Tests:** `export DATABASE_URL="postgresql+asyncpg://contex:contex_password@localhost:5432/contex_test"`. No new failures in `tests/` (~6 `sdk/python/tests` failures are known-unrelated).
+
+## File Structure
+
+- **New:** `src/core/ownership.py` (the helper), `tests/test_ownership.py`, `tests/test_tenant_isolation.py` (end-to-end matrix).
+- **Modify:** `src/api/routes.py` (#54 data routes, #55 cleanup, #43 key routes), `src/core/auth.py` (#43 revoke tenant check), `src/web/routes.py` (`/subscribe` ownership), and `src/api/{tenant_routes,webhook_routes,service_account_routes,audit_routes}.py` (remove `require_admin_permission`).
+
+---
+
+## Task 1: `check_project_access` helper
+
+**Files:** Create `src/core/ownership.py`; Test `tests/test_ownership.py`.
+
+**Interfaces — Produces:**
+`async def check_project_access(identity: Identity, project_id: str, tenant_mgr, *, create_if_absent: bool) -> None`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_ownership.py
+import pytest
+from unittest.mock import AsyncMock
+from fastapi import HTTPException
+
+from src.core import ownership
+from src.core.ownership import check_project_access
+from src.core.identity import Identity
+from src.core.rbac import Permission
+
+
+def _ident(tenant_id, projects=()):
+    return Identity(key_id="k", scopes=frozenset({Permission.PUBLISH_DATA}),
+                    tenant_id=tenant_id, projects=tuple(projects), role=None)
+
+
+@pytest.mark.asyncio
+async def test_noop_when_multitenant_off(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", False)
+    mgr = AsyncMock()
+    await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    mgr.get_project_tenant.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_noop_when_identity_has_no_tenant(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock()
+    await check_project_access(_ident(None), "p1", mgr, create_if_absent=False)
+    mgr.get_project_tenant.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_read_denies_unowned_project(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock(); mgr.get_project_tenant.return_value = None
+    with pytest.raises(HTTPException) as e:
+        await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    assert e.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_read_denies_other_tenant_project(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock(); mgr.get_project_tenant.return_value = "t2"
+    with pytest.raises(HTTPException) as e:
+        await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    assert e.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_read_allows_owned_project(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock(); mgr.get_project_tenant.return_value = "t1"
+    await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+
+
+@pytest.mark.asyncio
+async def test_publish_binds_new_project(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock(); mgr.get_project_tenant.return_value = None
+    await check_project_access(_ident("t1"), "pnew", mgr, create_if_absent=True)
+    mgr.add_project.assert_awaited_once_with("t1", "pnew")
+
+
+@pytest.mark.asyncio
+async def test_key_project_scope_denies_out_of_scope(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock()
+    with pytest.raises(HTTPException) as e:
+        await check_project_access(_ident("t1", projects=["allowed"]), "other", mgr, create_if_absent=True)
+    assert e.value.status_code == 403
+    mgr.get_project_tenant.assert_not_called()  # scope check short-circuits
+```
+
+- [ ] **Step 2: Run to verify failure** — `pytest tests/test_ownership.py -v` → module missing.
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/core/ownership.py
+"""Project→tenant ownership enforcement for authorized routes."""
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from src.core.identity import Identity
+from src.core.tenant_middleware import MULTI_TENANT_ENABLED
+
+
+async def check_project_access(
+    identity: Identity, project_id: str, tenant_mgr, *, create_if_absent: bool
+) -> None:
+    """Enforce that `project_id` belongs to the caller's tenant.
+
+    No-op when multi-tenancy is off or the caller carries no tenant. When
+    `create_if_absent` is true (publish paths), an unowned project is bound to
+    the caller's tenant; otherwise an unowned or cross-tenant project is denied.
+    """
+    if not MULTI_TENANT_ENABLED or identity.tenant_id is None:
+        return
+    if not identity.has_project(project_id):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    owner = await tenant_mgr.get_project_tenant(project_id)
+    if owner is None:
+        if create_if_absent:
+            await tenant_mgr.add_project(identity.tenant_id, project_id)
+            return
+        raise HTTPException(status_code=403, detail="Forbidden")
+    if owner != identity.tenant_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
+```
+
+- [ ] **Step 4: Run** — `pytest tests/test_ownership.py -v` → all pass.
+- [ ] **Step 5: Commit** — `feat(authz): project→tenant ownership helper (gated on multi-tenant)`.
+
+---
+
+## Task 2: Apply project ownership to data + cleanup routes (#54, #55)
+
+**Files:** Modify `src/api/routes.py`. Verify with `tests/test_auth.py`, `tests/test_retention.py`, `tests/test_publish_route_provenance.py`.
+
+**Interfaces — Consumes:** `check_project_access` (Task 1); `require` (existing); `get_tenant_manager` — **reuse the accessor pattern in `tenant_routes.py:95`** (a `get_tenant_manager(request)` returning a `TenantManager`); if it isn't importable/shared, add an equivalent local accessor in `routes.py` following that exact pattern (confirm the `TenantManager` constructor arg against `src/core/tenant.py`). If the accessor shape is ambiguous, STOP and report NEEDS_CONTEXT rather than guessing.
+
+For each route below: change `dependencies=[Depends(require(P))]` → add a parameter `identity: Identity = Depends(require(P))` (import `Identity` from `src.core.identity` at top), resolve `tenant_mgr = get_tenant_manager(request)`, and call the helper as the first line of the body (after existing arg parsing).
+
+| Route (routes.py) | Permission (unchanged) | Ownership call |
+|---|---|---|
+| POST `/data/publish` | PUBLISH_DATA | `await check_project_access(identity, event.project_id, tenant_mgr, create_if_absent=True)` |
+| POST `/data/upload` | PUBLISH_DATA | `create_if_absent=True` on the upload's project_id |
+| POST `/projects/{project_id}/import` | PUBLISH_DATA | `create_if_absent=True` |
+| POST `/batch/publish` | PUBLISH_DATA | `create_if_absent=True` for each distinct project_id in the batch |
+| POST `/projects/{project_id}/query` | QUERY_DATA | `create_if_absent=False` |
+| GET `/projects/{project_id}/events` | VIEW_PROJECT_EVENTS | `create_if_absent=False` |
+| GET `/projects/{project_id}/data` | VIEW_PROJECT_DATA | `create_if_absent=False` |
+| POST `/admin/cleanup/{project_id}` | SYSTEM_CLEANUP | `create_if_absent=False` (#55) |
+| GET `/admin/retention/{project_id}` | SYSTEM_CLEANUP | `create_if_absent=False` (#55) |
+
+Leave `POST /admin/cleanup` (all-projects) as-is — it is a global `SYSTEM_CLEANUP` op, not project-scoped; note in the report that per-tenant scoping of the global sweep is a separate consideration.
+
+- [ ] Step 1: add imports + accessor. Step 2: apply the table. Step 3: add tests to `tests/test_ownership.py` or a route test — with multi-tenant ON, a key for tenant A gets 403 on `GET /projects/{p_of_B}/data`, 200 on its own project, and publish to a new project binds it. With multi-tenant OFF, all pass unchanged. Step 4: `pytest tests/test_auth.py tests/test_retention.py tests/test_publish_route_provenance.py -v`. Step 5: commit `feat(authz): enforce project→tenant ownership on data and cleanup routes (#54, #55)`.
+
+---
+
+## Task 3: API-key tenant-scoping (#43)
+
+**Files:** Modify `src/api/routes.py` (the `/auth/keys` routes), `src/core/auth.py` (`revoke_api_key`). Test: `tests/test_auth.py`.
+
+**Interfaces — Consumes:** `identity: Identity = Depends(require(P))`.
+**Produces:** `revoke_api_key(db, key_id, tenant_id=None)` — when `tenant_id` is provided, only revokes a key whose `tenant_id` matches; returns False otherwise.
+
+- [ ] **Step 1: failing tests** — in `tests/test_auth.py`: `list_api_keys(db, tenant_id="t1")` returns only t1 keys; `revoke_api_key(db, key_id, tenant_id="t1")` returns False (no delete) when the key belongs to t2, True when it matches.
+- [ ] **Step 2: run → fail** (revoke signature).
+- [ ] **Step 3: implement**
+  - `src/core/auth.py`: add `tenant_id: Optional[str] = None` to `revoke_api_key`; when set, load the key first and only delete if `key.tenant_id == tenant_id`, else return False.
+  - `src/api/routes.py`:
+    - `GET /auth/keys`: take `identity: Identity = Depends(require(Permission.LIST_API_KEYS))`; call `list_api_keys(db, tenant_id=identity.tenant_id)`.
+    - `DELETE /auth/keys/{key_id}`: `identity = Depends(require(REVOKE_API_KEY))`; call `revoke_api_key(db, key_id, tenant_id=identity.tenant_id)`; 404/appropriate if it returns False.
+    - `POST /auth/keys`: `identity = Depends(require(CREATE_API_KEY))`; pass `tenant_id=identity.tenant_id` to `create_api_key` so new keys inherit the creator's tenant.
+  - Gate: when `identity.tenant_id is None` (single-tenant/tenant-less admin), pass `tenant_id=None` — preserves current cross-tenant behavior for un-tenanted admin keys. (Consistent with the Task 1 gating rationale.)
+- [ ] **Step 4: run** `pytest tests/test_auth.py -v`.
+- [ ] **Step 5: commit** `fix(authz): scope API key list/revoke/create to the caller's tenant (#43)`.
+
+---
+
+## Task 4: `/sandbox/subscribe` project-scope check
+
+**Files:** Modify `src/web/routes.py`. Test: `tests/test_sandbox_live.py` / `tests/test_sandbox_watch.py`.
+
+`/subscribe` already carries `require(Permission.QUERY_DATA)`. Change it to bind the identity and check ownership (read mode) so a hardened multi-tenant deployment can't stream another tenant's project.
+
+- [ ] Step 1: change `dependencies=[Depends(require(Permission.QUERY_DATA))]` → param `identity: Identity = Depends(require(Permission.QUERY_DATA))`; resolve `tenant_mgr` (same accessor); `await check_project_access(identity, project_id, tenant_mgr, create_if_absent=False)` before starting the stream. Step 2: existing sandbox tests still pass with auth off (helper is a no-op). Step 3: commit `fix(authz): scope sandbox /subscribe to the caller's tenant project`.
+
+---
+
+## Task 5: Remove the dead `require_admin_permission` guard (#39 remnant)
+
+**Files:** `src/api/tenant_routes.py`, `webhook_routes.py`, `service_account_routes.py`, `audit_routes.py`.
+
+The guard reads `request.state.api_key_role` (never set → fail-open) and is now redundant: every one of these routes already carries `require(Permission.MANAGE_*/VIEW_*)`, which is admin-only under the role map. Remove the four `async def require_admin_permission` definitions and every `_: None = Depends(require_admin_permission)` parameter (~28 sites). Change nothing else in the handlers.
+
+- [ ] Step 1: delete the definitions + all `Depends(require_admin_permission)` params. Step 2: `grep -rn "require_admin_permission" src/` → empty. Step 3: `pytest tests/test_tenant.py tests/test_webhooks.py tests/test_audit.py tests/test_security.py -v` (unchanged — require() still gates). Step 4: commit `chore(authz): remove redundant fail-open require_admin_permission guard (#39)`.
+
+---
+
+## Task 6: End-to-end multi-tenant isolation matrix
+
+**Files:** Create `tests/test_tenant_isolation.py`.
+
+With `MULTI_TENANT_ENABLED=true` and `AUTH_ENABLED=true` (monkeypatch `authz.auth_enabled`→True; set the env for `MULTI_TENANT_ENABLED` or monkeypatch `ownership.MULTI_TENANT_ENABLED`), against the real app with `get_identity` overridden to a tenant-A identity:
+- `GET /api/v1/projects/{B_project}/data` → 403; `{A_project}` → not 403.
+- `GET /api/v1/auth/keys` returns only tenant-A keys (seed keys for A and B).
+- Publish to a new project → binds to A (subsequent read by A allowed, by B 403).
+- With `MULTI_TENANT_ENABLED=false`: the same cross-tenant calls are NOT 403 (isolation off).
+
+- [ ] Step 1: write the tests (use `AsyncClient`+`ASGITransport`, `app.dependency_overrides[get_identity]`, seed via the `db` fixture; pre-create `TenantProject` rows for A/B). Step 2: run. Step 3: commit `test(authz): multi-tenant project + key isolation matrix`.
+
+---
+
+## Self-Review
+- **#43** → Task 3. **#54** → Task 2 (data routes). **#55** → Task 2 (cleanup routes). **/sandbox/subscribe** → Task 4. **#39 remnant** → Task 5. Helper + gating → Task 1. Isolation proof → Task 6.
+- **Placeholder scan:** helper + tests are concrete; route tasks use explicit mapping tables + the shared edit pattern. The one soft spot is the `get_tenant_manager` accessor/constructor shape — Task 2 instructs verify-or-NEEDS_CONTEXT rather than guess.
+- **Type consistency:** `check_project_access(identity, project_id, tenant_mgr, *, create_if_absent)`, `Identity` fields, `revoke_api_key(db, key_id, tenant_id=None)`, `list_api_keys(db, tenant_id=None)` used consistently across tasks.
+- **Gating consistency:** every ownership path is a no-op unless multi-tenant + identity.tenant_id — single-tenant/demo unaffected (verified in Task 1 tests and Task 6's multi-tenant-off case).

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from contextlib import asynccontextmanager
 from fastapi import Depends, FastAPI
+from fastapi.responses import JSONResponse
 from src.core.authz import public, auth_enabled
 from src.core.authz_coverage import assert_authz_coverage
 from src.core.protected_mode import check_protected_mode
@@ -279,6 +280,11 @@ app = FastAPI(
     version="0.2.0",
     lifespan=lifespan
 )
+
+@app.exception_handler(PermissionError)
+async def _permission_denied_handler(request, exc):
+    return JSONResponse(status_code=403, content={"detail": "Forbidden"})
+
 
 # Build the MCP server at module level with a lazy engine accessor so the
 # /mcp route exists in app.routes at import time (the test asserts this).

--- a/src/api/audit_routes.py
+++ b/src/api/audit_routes.py
@@ -13,7 +13,7 @@ from src.core.audit import (
     get_audit_logger,
 )
 from src.core.authz import require, public
-from src.core.rbac import Permission, Role
+from src.core.rbac import Permission
 from src.core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -66,19 +66,6 @@ class AuditExportResponse(BaseModel):
 # Helper Functions
 # ============================================================
 
-async def require_admin_permission(request: Request):
-    """Require admin role for audit access"""
-    role = getattr(request.state, 'api_key_role', None)
-    if role is None:
-        logger.warning("No RBAC context for audit access")
-        return
-    if role.role != Role.ADMIN:
-        raise HTTPException(
-            status_code=403,
-            detail="Admin role required to access audit logs"
-        )
-
-
 def get_audit_logger_dependency(request: Request) -> AuditLogger:
     """Get audit logger or raise if not available"""
     audit_logger = get_audit_logger()
@@ -127,7 +114,6 @@ async def query_audit_events(
     end_time: Optional[datetime] = Query(None, description="End of time range (ISO 8601)"),
     limit: int = Query(100, ge=1, le=1000, description="Maximum results"),
     offset: int = Query(0, ge=0, description="Skip first N results"),
-    _: None = Depends(require_admin_permission),
 ):
     """
     Query audit events with filtering.
@@ -178,7 +164,6 @@ async def query_audit_events(
 async def get_audit_event(
     request: Request,
     event_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Get a single audit event by ID.
@@ -195,9 +180,7 @@ async def get_audit_event(
 
 
 @router.get("/events/types", response_model=List[str], dependencies=[Depends(require(Permission.VIEW_AUDIT))])
-async def list_event_types(
-    _: None = Depends(require_admin_permission),
-):
+async def list_event_types():
     """
     List all available audit event types.
 
@@ -213,7 +196,6 @@ async def export_audit_events(
     start_time: Optional[datetime] = Query(None, description="Start of time range"),
     end_time: Optional[datetime] = Query(None, description="End of time range"),
     days: int = Query(30, ge=1, le=365, description="Number of days to export (if no start_time)"),
-    _: None = Depends(require_admin_permission),
 ):
     """
     Export audit events for compliance reporting.
@@ -265,7 +247,6 @@ async def get_audit_summary(
     request: Request,
     tenant_id: Optional[str] = Query(None, description="Filter by tenant ID"),
     days: int = Query(7, ge=1, le=90, description="Number of days for summary"),
-    _: None = Depends(require_admin_permission),
 ):
     """
     Get audit event summary statistics.

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -1,0 +1,8 @@
+"""Shared FastAPI dependencies for API routes."""
+from fastapi import Request
+
+from src.core.tenant import TenantManager
+
+
+def get_tenant_manager(request: Request) -> TenantManager:
+    return TenantManager(request.app.state.db)

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -113,13 +113,13 @@ async def metrics():
     return Response(content=metrics_output, media_type="text/plain; version=0.0.4")
 
 
-@router.post("/auth/keys", response_model=dict, dependencies=[Depends(require(Permission.CREATE_API_KEY))])
-async def create_key(name: str, request: Request):
+@router.post("/auth/keys", response_model=dict)
+async def create_key(name: str, request: Request, identity: Identity = Depends(require(Permission.CREATE_API_KEY))):
     """Create a new API key"""
     ctx = _get_request_context(request)
     try:
         db = request.app.state.db
-        raw_key, api_key = await create_api_key(db, name)
+        raw_key, api_key = await create_api_key(db, name, tenant_id=identity.tenant_id)
 
         # Audit log API key creation
         await audit_log(
@@ -148,23 +148,23 @@ async def create_key(name: str, request: Request):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/auth/keys", response_model=List[APIKey], dependencies=[Depends(require(Permission.LIST_API_KEYS))])
-async def list_keys(request: Request):
+@router.get("/auth/keys", response_model=List[APIKey])
+async def list_keys(request: Request, identity: Identity = Depends(require(Permission.LIST_API_KEYS))):
     """List all API keys"""
     try:
         db = request.app.state.db
-        return await list_api_keys(db)
+        return await list_api_keys(db, tenant_id=identity.tenant_id)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.delete("/auth/keys/{key_id}", dependencies=[Depends(require(Permission.REVOKE_API_KEY))])
-async def revoke_key(key_id: str, request: Request):
+@router.delete("/auth/keys/{key_id}")
+async def revoke_key(key_id: str, request: Request, identity: Identity = Depends(require(Permission.REVOKE_API_KEY))):
     """Revoke an API key"""
     ctx = _get_request_context(request)
     try:
         db = request.app.state.db
-        success = await revoke_api_key(db, key_id)
+        success = await revoke_api_key(db, key_id, tenant_id=identity.tenant_id)
         if not success:
             await audit_log(
                 event_type=AuditEventType.AUTH_API_KEY_REVOKED,

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File
 from src.api.deps import get_tenant_manager
 from src.core.authz import require, public, get_identity
 from src.core.identity import Identity
-from src.core.ownership import check_project_access
+from src.core.ownership import ensure_project_access
 from src.core.rbac import Permission
 from src.core.models import (
     AgentRegistration,
@@ -405,8 +405,7 @@ async def publish_data(event: DataPublishEvent, request: Request, identity: Iden
             "data": "We use a microservices architecture with Redis for caching"
         }
     """
-    if not await check_project_access(identity, event.project_id, get_tenant_manager(request), create_if_absent=True):
-        raise HTTPException(status_code=403, detail="Forbidden")
+    await ensure_project_access(identity, event.project_id, get_tenant_manager(request), create_if_absent=True)
     ctx = _get_request_context(request)
     try:
         from src.core.metrics import record_event_published, publish_duration_seconds
@@ -545,8 +544,7 @@ async def upload_document(
     import os
     import time
 
-    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=True):
-        raise HTTPException(status_code=403, detail="Forbidden")
+    await ensure_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=True)
     ctx = _get_request_context(request)
 
     # Determine format from file extension
@@ -803,8 +801,7 @@ async def get_agent_info(agent_id: str, request: Request):
 @router.get("/projects/{project_id}/events", dependencies=[Depends(require(Permission.VIEW_PROJECT_EVENTS))])
 async def get_project_events(project_id: str, request: Request, since: str = "0", count: int = 100, identity: Identity = Depends(get_identity)):
     """Get events for a project"""
-    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False):
-        raise HTTPException(status_code=403, detail="Forbidden")
+    await ensure_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
     engine = request.app.state.context_engine
     events = await engine.event_store.get_events_since(
         project_id,
@@ -838,8 +835,7 @@ async def get_project_data(
         include_embeddings: Include embeddings data
         include_agents: Include agent registrations
     """
-    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False):
-        raise HTTPException(status_code=403, detail="Forbidden")
+    await ensure_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
     ctx = _get_request_context(request)
     engine = request.app.state.context_engine
 
@@ -971,8 +967,7 @@ async def query_project(project_id: str, query_req: QueryRequest, request: Reque
         Complete data sources that match your search, ranked by semantic similarity,
         formatted as TOON or JSON.
     """
-    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False):
-        raise HTTPException(status_code=403, detail="Forbidden")
+    await ensure_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
     try:
         engine = request.app.state.context_engine
         matches = await engine.query_project_data(
@@ -1100,8 +1095,7 @@ async def cleanup_project(project_id: str, request: Request, identity: Identity 
     Returns:
         Cleanup statistics
     """
-    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False):
-        raise HTTPException(status_code=403, detail="Forbidden")
+    await ensure_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
     try:
         from src.core.retention import get_retention_manager_from_env
 
@@ -1134,8 +1128,7 @@ async def get_retention_stats(project_id: str, request: Request, identity: Ident
     Returns:
         Retention statistics
     """
-    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False):
-        raise HTTPException(status_code=403, detail="Forbidden")
+    await ensure_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
     try:
         from src.core.retention import get_retention_manager_from_env
 
@@ -1177,8 +1170,7 @@ async def import_project(
     Returns:
         Import statistics and validation results
     """
-    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=True):
-        raise HTTPException(status_code=403, detail="Forbidden")
+    await ensure_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=True)
     ctx = _get_request_context(request)
     try:
         from src.core.export_import import ExportImportManager
@@ -1291,8 +1283,7 @@ async def batch_publish_data(events: List[DataPublishEvent], request: Request, i
     """
     tenant_mgr = get_tenant_manager(request)
     for pid in {e.project_id for e in events}:
-        if not await check_project_access(identity, pid, tenant_mgr, create_if_absent=True):
-            raise HTTPException(status_code=403, detail="Forbidden")
+        await ensure_project_access(identity, pid, tenant_mgr, create_if_absent=True)
     try:
         import time
         from src.core.metrics import record_event_published, publish_duration_seconds

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -2,7 +2,10 @@
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form
 from src.core.authz import require, public
+from src.core.identity import Identity
+from src.core.ownership import check_project_access
 from src.core.rbac import Permission
+from src.core.tenant import TenantManager
 from src.core.models import (
     AgentRegistration,
     DataPublishEvent,
@@ -26,6 +29,10 @@ from typing import List
 
 router = APIRouter()
 logger = get_logger(__name__)
+
+
+def get_tenant_manager(request: Request) -> TenantManager:
+    return TenantManager(request.app.state.db)
 
 
 def _get_request_context(request: Request) -> dict:
@@ -364,8 +371,8 @@ async def list_permissions():
     }
 
 
-@router.post("/data/publish", response_model=dict, dependencies=[Depends(require(Permission.PUBLISH_DATA))])
-async def publish_data(event: DataPublishEvent, request: Request):
+@router.post("/data/publish", response_model=dict)
+async def publish_data(event: DataPublishEvent, request: Request, identity: Identity = Depends(require(Permission.PUBLISH_DATA))):
     """
     Main app publishes data change in ANY format.
 
@@ -402,6 +409,7 @@ async def publish_data(event: DataPublishEvent, request: Request):
             "data": "We use a microservices architecture with Redis for caching"
         }
     """
+    await check_project_access(identity, event.project_id, get_tenant_manager(request), create_if_absent=True)
     ctx = _get_request_context(request)
     try:
         from src.core.metrics import record_event_published, publish_duration_seconds
@@ -512,12 +520,13 @@ BINARY_FORMATS = {"pdf", "docx"}
 MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
 
 
-@router.post("/data/upload", response_model=dict, dependencies=[Depends(require(Permission.PUBLISH_DATA))])
+@router.post("/data/upload", response_model=dict)
 async def upload_document(
     request: Request,
     file: UploadFile = File(..., description="Document file (PDF, DOCX, or any supported text format)"),
     project_id: str = Form(..., description="Project identifier"),
     data_key: str = Form(None, description="Data identifier (defaults to filename without extension)"),
+    identity: Identity = Depends(require(Permission.PUBLISH_DATA)),
 ):
     """
     Upload a document file for indexing.
@@ -539,6 +548,7 @@ async def upload_document(
     import os
     import time
 
+    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=True)
     ctx = _get_request_context(request)
 
     # Determine format from file extension
@@ -792,9 +802,10 @@ async def get_agent_info(agent_id: str, request: Request):
     return info
 
 
-@router.get("/projects/{project_id}/events", dependencies=[Depends(require(Permission.VIEW_PROJECT_EVENTS))])
-async def get_project_events(project_id: str, request: Request, since: str = "0", count: int = 100):
+@router.get("/projects/{project_id}/events")
+async def get_project_events(project_id: str, request: Request, since: str = "0", count: int = 100, identity: Identity = Depends(require(Permission.VIEW_PROJECT_EVENTS))):
     """Get events for a project"""
+    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
     engine = request.app.state.context_engine
     events = await engine.event_store.get_events_since(
         project_id,
@@ -804,7 +815,7 @@ async def get_project_events(project_id: str, request: Request, since: str = "0"
     return {"events": events, "count": len(events)}
 
 
-@router.get("/projects/{project_id}/data", dependencies=[Depends(require(Permission.VIEW_PROJECT_DATA))])
+@router.get("/projects/{project_id}/data")
 async def get_project_data(
     project_id: str,
     request: Request,
@@ -813,6 +824,7 @@ async def get_project_data(
     include_events: bool = False,
     include_embeddings: bool = False,
     include_agents: bool = False,
+    identity: Identity = Depends(require(Permission.VIEW_PROJECT_DATA)),
 ):
     """
     Get all registered data for a project.
@@ -827,6 +839,7 @@ async def get_project_data(
         include_embeddings: Include embeddings data
         include_agents: Include agent registrations
     """
+    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
     ctx = _get_request_context(request)
     engine = request.app.state.context_engine
 
@@ -934,8 +947,8 @@ async def get_project_data(
     return result
 
 
-@router.post("/projects/{project_id}/query", dependencies=[Depends(require(Permission.QUERY_DATA))])
-async def query_project(project_id: str, query_req: QueryRequest, request: Request):
+@router.post("/projects/{project_id}/query")
+async def query_project(project_id: str, query_req: QueryRequest, request: Request, identity: Identity = Depends(require(Permission.QUERY_DATA))):
     """
     Search project data by semantic similarity without agent registration.
 
@@ -958,6 +971,7 @@ async def query_project(project_id: str, query_req: QueryRequest, request: Reque
         Complete data sources that match your search, ranked by semantic similarity,
         formatted as TOON or JSON.
     """
+    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
     try:
         engine = request.app.state.context_engine
         matches = await engine.query_project_data(
@@ -1074,8 +1088,8 @@ async def cleanup_all_projects(request: Request):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/admin/cleanup/{project_id}", dependencies=[Depends(require(Permission.SYSTEM_CLEANUP))])
-async def cleanup_project(project_id: str, request: Request):
+@router.post("/admin/cleanup/{project_id}")
+async def cleanup_project(project_id: str, request: Request, identity: Identity = Depends(require(Permission.SYSTEM_CLEANUP))):
     """
     Run cleanup for a specific project (admin only).
 
@@ -1085,6 +1099,7 @@ async def cleanup_project(project_id: str, request: Request):
     Returns:
         Cleanup statistics
     """
+    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
     try:
         from src.core.retention import get_retention_manager_from_env
 
@@ -1106,8 +1121,8 @@ async def cleanup_project(project_id: str, request: Request):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/admin/retention/{project_id}", dependencies=[Depends(require(Permission.SYSTEM_CLEANUP))])
-async def get_retention_stats(project_id: str, request: Request):
+@router.get("/admin/retention/{project_id}")
+async def get_retention_stats(project_id: str, request: Request, identity: Identity = Depends(require(Permission.SYSTEM_CLEANUP))):
     """
     Get retention statistics for a project.
 
@@ -1117,6 +1132,7 @@ async def get_retention_stats(project_id: str, request: Request):
     Returns:
         Retention statistics
     """
+    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
     try:
         from src.core.retention import get_retention_manager_from_env
 
@@ -1137,13 +1153,14 @@ async def get_retention_stats(project_id: str, request: Request):
 # Import Endpoints
 # ========================================================================
 
-@router.post("/projects/{project_id}/import", dependencies=[Depends(require(Permission.PUBLISH_DATA))])
+@router.post("/projects/{project_id}/import")
 async def import_project(
     project_id: str,
     request: Request,
     format: str = "json",
     validate_only: bool = False,
     overwrite: bool = False,
+    identity: Identity = Depends(require(Permission.PUBLISH_DATA)),
 ):
     """
     Import project data.
@@ -1157,6 +1174,7 @@ async def import_project(
     Returns:
         Import statistics and validation results
     """
+    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=True)
     ctx = _get_request_context(request)
     try:
         from src.core.export_import import ExportImportManager
@@ -1236,8 +1254,8 @@ async def import_project(
 # BATCH OPERATIONS - Phase 2 Performance Enhancement
 # ============================================================================
 
-@router.post("/batch/publish", response_model=dict, dependencies=[Depends(require(Permission.PUBLISH_DATA))])
-async def batch_publish_data(events: List[DataPublishEvent], request: Request):
+@router.post("/batch/publish", response_model=dict)
+async def batch_publish_data(events: List[DataPublishEvent], request: Request, identity: Identity = Depends(require(Permission.PUBLISH_DATA))):
     """
     Batch publish multiple data items in a single request.
 
@@ -1274,13 +1292,18 @@ async def batch_publish_data(events: List[DataPublishEvent], request: Request):
         logger.info(f"Batch publishing {len(events)} items")
         start_time = time.time()
         engine = request.app.state.context_engine
+        tenant_mgr = get_tenant_manager(request)
 
         results = []
         successful = 0
         failed = 0
 
+        seen_projects: set[str] = set()
         for event in events:
             try:
+                if event.project_id not in seen_projects:
+                    await check_project_access(identity, event.project_id, tenant_mgr, create_if_absent=True)
+                    seen_projects.add(event.project_id)
                 sequence = await engine.publish_data(event)
                 record_event_published(event.project_id, event.data_format or "json")
                 results.append({

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -1289,6 +1289,10 @@ async def batch_publish_data(events: List[DataPublishEvent], request: Request, i
             "results": [...]
         }
     """
+    tenant_mgr = get_tenant_manager(request)
+    for pid in {e.project_id for e in events}:
+        if not await check_project_access(identity, pid, tenant_mgr, create_if_absent=True):
+            raise HTTPException(status_code=403, detail="Forbidden")
     try:
         import time
         from src.core.metrics import record_event_published, publish_duration_seconds
@@ -1296,19 +1300,13 @@ async def batch_publish_data(events: List[DataPublishEvent], request: Request, i
         logger.info(f"Batch publishing {len(events)} items")
         start_time = time.time()
         engine = request.app.state.context_engine
-        tenant_mgr = get_tenant_manager(request)
 
         results = []
         successful = 0
         failed = 0
 
-        seen_projects: set[str] = set()
         for event in events:
             try:
-                if event.project_id not in seen_projects:
-                    if not await check_project_access(identity, event.project_id, tenant_mgr, create_if_absent=True):
-                        raise HTTPException(status_code=403, detail="Forbidden")
-                    seen_projects.add(event.project_id)
                 sequence = await engine.publish_data(event)
                 record_event_published(event.project_id, event.data_format or "json")
                 results.append({
@@ -1345,6 +1343,8 @@ async def batch_publish_data(events: List[DataPublishEvent], request: Request, i
             "results": results
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Batch publish failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -1,11 +1,11 @@
 """REST API routes for Contex"""
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Form
-from src.core.authz import require, public
+from src.api.deps import get_tenant_manager
+from src.core.authz import require, public, get_identity
 from src.core.identity import Identity
 from src.core.ownership import check_project_access
 from src.core.rbac import Permission
-from src.core.tenant import TenantManager
 from src.core.models import (
     AgentRegistration,
     DataPublishEvent,
@@ -29,10 +29,6 @@ from typing import List
 
 router = APIRouter()
 logger = get_logger(__name__)
-
-
-def get_tenant_manager(request: Request) -> TenantManager:
-    return TenantManager(request.app.state.db)
 
 
 def _get_request_context(request: Request) -> dict:
@@ -113,8 +109,8 @@ async def metrics():
     return Response(content=metrics_output, media_type="text/plain; version=0.0.4")
 
 
-@router.post("/auth/keys", response_model=dict)
-async def create_key(name: str, request: Request, identity: Identity = Depends(require(Permission.CREATE_API_KEY))):
+@router.post("/auth/keys", response_model=dict, dependencies=[Depends(require(Permission.CREATE_API_KEY))])
+async def create_key(name: str, request: Request, identity: Identity = Depends(get_identity)):
     """Create a new API key"""
     ctx = _get_request_context(request)
     try:
@@ -148,8 +144,8 @@ async def create_key(name: str, request: Request, identity: Identity = Depends(r
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/auth/keys", response_model=List[APIKey])
-async def list_keys(request: Request, identity: Identity = Depends(require(Permission.LIST_API_KEYS))):
+@router.get("/auth/keys", response_model=List[APIKey], dependencies=[Depends(require(Permission.LIST_API_KEYS))])
+async def list_keys(request: Request, identity: Identity = Depends(get_identity)):
     """List all API keys"""
     try:
         db = request.app.state.db
@@ -158,8 +154,8 @@ async def list_keys(request: Request, identity: Identity = Depends(require(Permi
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.delete("/auth/keys/{key_id}")
-async def revoke_key(key_id: str, request: Request, identity: Identity = Depends(require(Permission.REVOKE_API_KEY))):
+@router.delete("/auth/keys/{key_id}", dependencies=[Depends(require(Permission.REVOKE_API_KEY))])
+async def revoke_key(key_id: str, request: Request, identity: Identity = Depends(get_identity)):
     """Revoke an API key"""
     ctx = _get_request_context(request)
     try:
@@ -371,8 +367,8 @@ async def list_permissions():
     }
 
 
-@router.post("/data/publish", response_model=dict)
-async def publish_data(event: DataPublishEvent, request: Request, identity: Identity = Depends(require(Permission.PUBLISH_DATA))):
+@router.post("/data/publish", response_model=dict, dependencies=[Depends(require(Permission.PUBLISH_DATA))])
+async def publish_data(event: DataPublishEvent, request: Request, identity: Identity = Depends(get_identity)):
     """
     Main app publishes data change in ANY format.
 
@@ -409,7 +405,8 @@ async def publish_data(event: DataPublishEvent, request: Request, identity: Iden
             "data": "We use a microservices architecture with Redis for caching"
         }
     """
-    await check_project_access(identity, event.project_id, get_tenant_manager(request), create_if_absent=True)
+    if not await check_project_access(identity, event.project_id, get_tenant_manager(request), create_if_absent=True):
+        raise HTTPException(status_code=403, detail="Forbidden")
     ctx = _get_request_context(request)
     try:
         from src.core.metrics import record_event_published, publish_duration_seconds
@@ -520,13 +517,13 @@ BINARY_FORMATS = {"pdf", "docx"}
 MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
 
 
-@router.post("/data/upload", response_model=dict)
+@router.post("/data/upload", response_model=dict, dependencies=[Depends(require(Permission.PUBLISH_DATA))])
 async def upload_document(
     request: Request,
     file: UploadFile = File(..., description="Document file (PDF, DOCX, or any supported text format)"),
     project_id: str = Form(..., description="Project identifier"),
     data_key: str = Form(None, description="Data identifier (defaults to filename without extension)"),
-    identity: Identity = Depends(require(Permission.PUBLISH_DATA)),
+    identity: Identity = Depends(get_identity),
 ):
     """
     Upload a document file for indexing.
@@ -548,7 +545,8 @@ async def upload_document(
     import os
     import time
 
-    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=True)
+    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=True):
+        raise HTTPException(status_code=403, detail="Forbidden")
     ctx = _get_request_context(request)
 
     # Determine format from file extension
@@ -802,10 +800,11 @@ async def get_agent_info(agent_id: str, request: Request):
     return info
 
 
-@router.get("/projects/{project_id}/events")
-async def get_project_events(project_id: str, request: Request, since: str = "0", count: int = 100, identity: Identity = Depends(require(Permission.VIEW_PROJECT_EVENTS))):
+@router.get("/projects/{project_id}/events", dependencies=[Depends(require(Permission.VIEW_PROJECT_EVENTS))])
+async def get_project_events(project_id: str, request: Request, since: str = "0", count: int = 100, identity: Identity = Depends(get_identity)):
     """Get events for a project"""
-    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
+    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False):
+        raise HTTPException(status_code=403, detail="Forbidden")
     engine = request.app.state.context_engine
     events = await engine.event_store.get_events_since(
         project_id,
@@ -815,7 +814,7 @@ async def get_project_events(project_id: str, request: Request, since: str = "0"
     return {"events": events, "count": len(events)}
 
 
-@router.get("/projects/{project_id}/data")
+@router.get("/projects/{project_id}/data", dependencies=[Depends(require(Permission.VIEW_PROJECT_DATA))])
 async def get_project_data(
     project_id: str,
     request: Request,
@@ -824,7 +823,7 @@ async def get_project_data(
     include_events: bool = False,
     include_embeddings: bool = False,
     include_agents: bool = False,
-    identity: Identity = Depends(require(Permission.VIEW_PROJECT_DATA)),
+    identity: Identity = Depends(get_identity),
 ):
     """
     Get all registered data for a project.
@@ -839,7 +838,8 @@ async def get_project_data(
         include_embeddings: Include embeddings data
         include_agents: Include agent registrations
     """
-    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
+    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False):
+        raise HTTPException(status_code=403, detail="Forbidden")
     ctx = _get_request_context(request)
     engine = request.app.state.context_engine
 
@@ -947,8 +947,8 @@ async def get_project_data(
     return result
 
 
-@router.post("/projects/{project_id}/query")
-async def query_project(project_id: str, query_req: QueryRequest, request: Request, identity: Identity = Depends(require(Permission.QUERY_DATA))):
+@router.post("/projects/{project_id}/query", dependencies=[Depends(require(Permission.QUERY_DATA))])
+async def query_project(project_id: str, query_req: QueryRequest, request: Request, identity: Identity = Depends(get_identity)):
     """
     Search project data by semantic similarity without agent registration.
 
@@ -971,7 +971,8 @@ async def query_project(project_id: str, query_req: QueryRequest, request: Reque
         Complete data sources that match your search, ranked by semantic similarity,
         formatted as TOON or JSON.
     """
-    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
+    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False):
+        raise HTTPException(status_code=403, detail="Forbidden")
     try:
         engine = request.app.state.context_engine
         matches = await engine.query_project_data(
@@ -1088,8 +1089,8 @@ async def cleanup_all_projects(request: Request):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/admin/cleanup/{project_id}")
-async def cleanup_project(project_id: str, request: Request, identity: Identity = Depends(require(Permission.SYSTEM_CLEANUP))):
+@router.post("/admin/cleanup/{project_id}", dependencies=[Depends(require(Permission.SYSTEM_CLEANUP))])
+async def cleanup_project(project_id: str, request: Request, identity: Identity = Depends(get_identity)):
     """
     Run cleanup for a specific project (admin only).
 
@@ -1099,7 +1100,8 @@ async def cleanup_project(project_id: str, request: Request, identity: Identity 
     Returns:
         Cleanup statistics
     """
-    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
+    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False):
+        raise HTTPException(status_code=403, detail="Forbidden")
     try:
         from src.core.retention import get_retention_manager_from_env
 
@@ -1121,8 +1123,8 @@ async def cleanup_project(project_id: str, request: Request, identity: Identity 
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/admin/retention/{project_id}")
-async def get_retention_stats(project_id: str, request: Request, identity: Identity = Depends(require(Permission.SYSTEM_CLEANUP))):
+@router.get("/admin/retention/{project_id}", dependencies=[Depends(require(Permission.SYSTEM_CLEANUP))])
+async def get_retention_stats(project_id: str, request: Request, identity: Identity = Depends(get_identity)):
     """
     Get retention statistics for a project.
 
@@ -1132,7 +1134,8 @@ async def get_retention_stats(project_id: str, request: Request, identity: Ident
     Returns:
         Retention statistics
     """
-    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False)
+    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=False):
+        raise HTTPException(status_code=403, detail="Forbidden")
     try:
         from src.core.retention import get_retention_manager_from_env
 
@@ -1153,14 +1156,14 @@ async def get_retention_stats(project_id: str, request: Request, identity: Ident
 # Import Endpoints
 # ========================================================================
 
-@router.post("/projects/{project_id}/import")
+@router.post("/projects/{project_id}/import", dependencies=[Depends(require(Permission.PUBLISH_DATA))])
 async def import_project(
     project_id: str,
     request: Request,
     format: str = "json",
     validate_only: bool = False,
     overwrite: bool = False,
-    identity: Identity = Depends(require(Permission.PUBLISH_DATA)),
+    identity: Identity = Depends(get_identity),
 ):
     """
     Import project data.
@@ -1174,7 +1177,8 @@ async def import_project(
     Returns:
         Import statistics and validation results
     """
-    await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=True)
+    if not await check_project_access(identity, project_id, get_tenant_manager(request), create_if_absent=True):
+        raise HTTPException(status_code=403, detail="Forbidden")
     ctx = _get_request_context(request)
     try:
         from src.core.export_import import ExportImportManager
@@ -1254,8 +1258,8 @@ async def import_project(
 # BATCH OPERATIONS - Phase 2 Performance Enhancement
 # ============================================================================
 
-@router.post("/batch/publish", response_model=dict)
-async def batch_publish_data(events: List[DataPublishEvent], request: Request, identity: Identity = Depends(require(Permission.PUBLISH_DATA))):
+@router.post("/batch/publish", response_model=dict, dependencies=[Depends(require(Permission.PUBLISH_DATA))])
+async def batch_publish_data(events: List[DataPublishEvent], request: Request, identity: Identity = Depends(get_identity)):
     """
     Batch publish multiple data items in a single request.
 
@@ -1302,7 +1306,8 @@ async def batch_publish_data(events: List[DataPublishEvent], request: Request, i
         for event in events:
             try:
                 if event.project_id not in seen_projects:
-                    await check_project_access(identity, event.project_id, tenant_mgr, create_if_absent=True)
+                    if not await check_project_access(identity, event.project_id, tenant_mgr, create_if_absent=True):
+                        raise HTTPException(status_code=403, detail="Forbidden")
                     seen_projects.add(event.project_id)
                 sequence = await engine.publish_data(event)
                 record_event_published(event.project_id, event.data_format or "json")

--- a/src/api/service_account_routes.py
+++ b/src/api/service_account_routes.py
@@ -135,19 +135,6 @@ def get_manager(request: Request) -> ServiceAccountManager:
     return manager
 
 
-async def require_admin_permission(request: Request):
-    """Require admin role for service account management"""
-    role = getattr(request.state, 'api_key_role', None)
-    if role is None:
-        logger.warning("No RBAC context for service account management")
-        return
-    if role.role != Role.ADMIN:
-        raise HTTPException(
-            status_code=403,
-            detail="Admin role required for service account management"
-        )
-
-
 def account_to_response(account: ServiceAccount) -> ServiceAccountResponse:
     """Convert ServiceAccount to response model"""
     return ServiceAccountResponse(
@@ -185,7 +172,6 @@ def account_to_response(account: ServiceAccount) -> ServiceAccountResponse:
 async def create_service_account(
     request: Request,
     body: CreateServiceAccountRequest,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Create a new service account.
@@ -241,7 +227,6 @@ async def list_service_accounts(
     account_type: Optional[ServiceAccountType] = None,
     is_active: Optional[bool] = None,
     limit: int = 100,
-    _: None = Depends(require_admin_permission),
 ):
     """
     List service accounts.
@@ -265,7 +250,6 @@ async def list_service_accounts(
 async def get_service_account(
     request: Request,
     account_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Get service account by ID.
@@ -286,7 +270,6 @@ async def update_service_account(
     request: Request,
     account_id: str,
     body: UpdateServiceAccountRequest,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Update service account.
@@ -326,7 +309,6 @@ async def update_service_account(
 async def delete_service_account(
     request: Request,
     account_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Delete service account.
@@ -356,7 +338,6 @@ async def create_key(
     request: Request,
     account_id: str,
     body: CreateKeyRequest,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Create a new key for a service account.
@@ -406,7 +387,6 @@ async def revoke_key(
     request: Request,
     account_id: str,
     key_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Revoke a service account key.

--- a/src/api/tenant_routes.py
+++ b/src/api/tenant_routes.py
@@ -4,9 +4,9 @@ from typing import List, Optional, Dict, Any
 from fastapi import APIRouter, HTTPException, Request, Depends
 from pydantic import BaseModel, Field
 
+from src.api.deps import get_tenant_manager
 from src.core.tenant import (
     TenantManager,
-    Tenant,
     TenantPlan,
     TenantQuotas,
     TenantUsage,
@@ -86,18 +86,6 @@ class TenantUsageResponse(BaseModel):
     usage: TenantUsage
     quotas: TenantQuotas
     usage_percentage: Dict[str, float]
-
-
-# ============================================================
-# Helper Functions
-# ============================================================
-
-def get_tenant_manager(request: Request) -> TenantManager:
-    """Get TenantManager from request state or create new one"""
-    manager = getattr(request.state, 'tenant_manager', None)
-    if not manager:
-        manager = TenantManager(request.app.state.db)
-    return manager
 
 
 # ============================================================

--- a/src/api/tenant_routes.py
+++ b/src/api/tenant_routes.py
@@ -12,7 +12,7 @@ from src.core.tenant import (
     TenantUsage,
 )
 from src.core.authz import require, public
-from src.core.rbac import Role, Permission
+from src.core.rbac import Permission
 from src.core.logging import get_logger
 from src.core.audit import (
     audit_log,
@@ -100,27 +100,6 @@ def get_tenant_manager(request: Request) -> TenantManager:
     return manager
 
 
-async def require_admin_permission(request: Request):
-    """
-    Dependency to require admin permission for tenant management.
-
-    In production, this should check the API key's role.
-    """
-    # Get role from request state (set by RBAC middleware)
-    role = getattr(request.state, 'api_key_role', None)
-
-    if role is None:
-        # For now, allow if no RBAC middleware (development mode)
-        logger.warning("No RBAC context, allowing tenant management")
-        return
-
-    if role.role != Role.ADMIN:
-        raise HTTPException(
-            status_code=403,
-            detail="Admin role required for tenant management"
-        )
-
-
 # ============================================================
 # Tenant CRUD Endpoints
 # ============================================================
@@ -129,7 +108,6 @@ async def require_admin_permission(request: Request):
 async def create_tenant(
     request: Request,
     body: CreateTenantRequest,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Create a new tenant.
@@ -206,7 +184,6 @@ async def list_tenants(
     is_active: Optional[bool] = None,
     limit: int = 100,
     offset: int = 0,
-    _: None = Depends(require_admin_permission),
 ):
     """
     List all tenants with optional filtering.
@@ -254,7 +231,6 @@ async def list_tenants(
 async def get_tenant(
     request: Request,
     tenant_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Get tenant by ID.
@@ -291,7 +267,6 @@ async def update_tenant(
     request: Request,
     tenant_id: str,
     body: UpdateTenantRequest,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Update tenant properties.
@@ -363,7 +338,6 @@ async def delete_tenant(
     request: Request,
     tenant_id: str,
     force: bool = False,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Delete a tenant.
@@ -420,7 +394,6 @@ async def delete_tenant(
 async def get_tenant_usage(
     request: Request,
     tenant_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Get current usage for a tenant.
@@ -464,7 +437,6 @@ async def get_tenant_usage(
 async def reset_monthly_usage(
     request: Request,
     tenant_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Reset monthly usage counters for a tenant.
@@ -497,7 +469,6 @@ async def reset_monthly_usage(
 async def list_tenant_projects(
     request: Request,
     tenant_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     List all projects for a tenant.
@@ -524,7 +495,6 @@ async def add_project_to_tenant(
     request: Request,
     tenant_id: str,
     project_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Add a project to a tenant.
@@ -560,7 +530,6 @@ async def remove_project_from_tenant(
     request: Request,
     tenant_id: str,
     project_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Remove a project from a tenant.

--- a/src/api/webhook_routes.py
+++ b/src/api/webhook_routes.py
@@ -16,7 +16,7 @@ from src.core.webhooks import (
     init_webhook_manager,
 )
 from src.core.authz import require, public
-from src.core.rbac import Permission, Role
+from src.core.rbac import Permission
 from src.core.logging import get_logger
 from src.core.audit import (
     audit_log,
@@ -149,19 +149,6 @@ async def get_manager(request: Request) -> WebhookManager:
     return manager
 
 
-async def require_admin_permission(request: Request):
-    """Require admin role for webhook management"""
-    role = getattr(request.state, 'api_key_role', None)
-    if role is None:
-        logger.warning("No RBAC context for webhook management")
-        return
-    if role.role != Role.ADMIN:
-        raise HTTPException(
-            status_code=403,
-            detail="Admin role required for webhook management"
-        )
-
-
 def endpoint_to_response(endpoint: WebhookEndpoint) -> EndpointResponse:
     """Convert endpoint to response model (without secret)"""
     return EndpointResponse(
@@ -234,7 +221,6 @@ async def get_event_types():
 async def create_endpoint(
     request: Request,
     body: CreateEndpointRequest,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Create a new webhook endpoint.
@@ -301,7 +287,6 @@ async def create_endpoint(
 async def list_endpoints(
     request: Request,
     is_active: Optional[bool] = Query(None, description="Filter by active status"),
-    _: None = Depends(require_admin_permission),
 ):
     """
     List all webhook endpoints.
@@ -323,7 +308,6 @@ async def list_endpoints(
 async def get_endpoint(
     request: Request,
     endpoint_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Get webhook endpoint by ID.
@@ -344,7 +328,6 @@ async def update_endpoint(
     request: Request,
     endpoint_id: str,
     body: UpdateEndpointRequest,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Update a webhook endpoint.
@@ -378,7 +361,6 @@ async def update_endpoint(
 async def delete_endpoint(
     request: Request,
     endpoint_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Delete a webhook endpoint.
@@ -407,7 +389,6 @@ async def delete_endpoint(
 async def rotate_secret(
     request: Request,
     endpoint_id: str,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Rotate the webhook secret.
@@ -452,7 +433,6 @@ async def get_deliveries(
     request: Request,
     endpoint_id: str,
     limit: int = Query(default=50, ge=1, le=100),
-    _: None = Depends(require_admin_permission),
 ):
     """
     Get delivery log for an endpoint.
@@ -492,7 +472,6 @@ async def send_test_event(
     request: Request,
     endpoint_id: str,
     body: TestEventRequest,
-    _: None = Depends(require_admin_permission),
 ):
     """
     Send a test event to an endpoint.

--- a/src/core/auth.py
+++ b/src/core/auth.py
@@ -118,20 +118,36 @@ async def create_api_key(
     return raw_key, api_key
 
 
-async def revoke_api_key(db: DatabaseManager, key_id: str) -> bool:
+async def revoke_api_key(
+    db: DatabaseManager, key_id: str, tenant_id: Optional[str] = None
+) -> bool:
     """
     Revoke an API key by ID.
 
     Args:
         db: Database manager
         key_id: Key ID to revoke
+        tenant_id: When provided, only revokes the key if it belongs to this tenant
 
     Returns:
-        True if key was revoked, False if not found
+        True if key was revoked, False if not found or tenant mismatch
     """
     from sqlalchemy import delete
 
     async with db.session() as session:
+        if tenant_id is not None:
+            result = await session.execute(
+                select(APIKeyModel).where(APIKeyModel.key_id == key_id)
+            )
+            key = result.scalar_one_or_none()
+            if key is None or key.tenant_id != tenant_id:
+                return False
+            await session.execute(
+                delete(APIKeyModel).where(APIKeyModel.key_id == key_id)
+            )
+            logger.info("API key revoked", key_id=key_id)
+            return True
+
         result = await session.execute(
             delete(APIKeyModel).where(APIKeyModel.key_id == key_id)
         )

--- a/src/core/auth.py
+++ b/src/core/auth.py
@@ -137,16 +137,15 @@ async def revoke_api_key(
     async with db.session() as session:
         if tenant_id is not None:
             result = await session.execute(
-                select(APIKeyModel).where(APIKeyModel.key_id == key_id)
+                delete(APIKeyModel).where(
+                    APIKeyModel.key_id == key_id,
+                    APIKeyModel.tenant_id == tenant_id,
+                )
             )
-            key = result.scalar_one_or_none()
-            if key is None or key.tenant_id != tenant_id:
-                return False
-            await session.execute(
-                delete(APIKeyModel).where(APIKeyModel.key_id == key_id)
-            )
-            logger.info("API key revoked", key_id=key_id)
-            return True
+            if result.rowcount > 0:
+                logger.info("API key revoked", key_id=key_id)
+                return True
+            return False
 
         result = await session.execute(
             delete(APIKeyModel).where(APIKeyModel.key_id == key_id)

--- a/src/core/mcp_adapter.py
+++ b/src/core/mcp_adapter.py
@@ -97,8 +97,10 @@ def build_mcp_server(engine, db_accessor=None):
     async def contex_create_subscription(project_id: str, needs: list[str],
                                          top_k: int = 5, threshold: float | None = None) -> str:
         _enforce(Permission.QUERY_DATA, project_id=project_id)
+        tok = get_access_token()
+        tid = (tok.claims or {}).get("tenant_id") if tok else None
         e = _get_engine()
-        sub_id = await e.subscriptions.create(project_id, needs, top_k=top_k, threshold=threshold)
+        sub_id = await e.subscriptions.create(project_id, needs, tenant_id=tid, top_k=top_k, threshold=threshold)
         return json.dumps({"subscription_id": sub_id, "resource_uri": f"contex://subscriptions/{sub_id}"})
 
     @server.tool(name="contex_delete_subscription", description="Delete a subscription.")

--- a/src/core/mcp_adapter.py
+++ b/src/core/mcp_adapter.py
@@ -104,8 +104,10 @@ def build_mcp_server(engine, db_accessor=None):
     @server.tool(name="contex_delete_subscription", description="Delete a subscription.")
     async def contex_delete_subscription(subscription_id: str) -> str:
         _enforce(Permission.QUERY_DATA)
+        tok = get_access_token()
+        tid = (tok.claims or {}).get("tenant_id") if tok else None
         e = _get_engine()
-        await e.subscriptions.delete(subscription_id)
+        await e.subscriptions.delete(subscription_id, tenant_id=tid)
         return json.dumps({"deleted": subscription_id})
 
     @server.resource("contex://subscriptions/{id}", name="subscription",
@@ -113,8 +115,10 @@ def build_mcp_server(engine, db_accessor=None):
                      mime_type="application/json")
     async def read_subscription(id: str) -> str:
         _enforce(Permission.QUERY_DATA)
+        tok = get_access_token()
+        tid = (tok.claims or {}).get("tenant_id") if tok else None
         e = _get_engine()
-        return json.dumps(await e.subscriptions.get_bundle(id))
+        return json.dumps(await e.subscriptions.get_bundle(id, tenant_id=tid))
 
     @server.tool(name="contex_publish", description="Publish/update context data for a project.")
     async def contex_publish(project_id: str, data_key: str, data: dict, data_format: str = "json") -> str:

--- a/src/core/ownership.py
+++ b/src/core/ownership.py
@@ -5,24 +5,25 @@ from src.core.identity import Identity
 from src.core.tenant_middleware import MULTI_TENANT_ENABLED
 
 
-async def check_project_access(
+async def ensure_project_access(
     identity: Identity, project_id: str, tenant_mgr, *, create_if_absent: bool
-) -> bool:
-    """Return True when `project_id` is accessible to the caller's tenant.
+) -> None:
+    """Raise PermissionError if the caller's tenant may not access `project_id`.
 
-    Returns True (allowed) when multi-tenancy is off or the caller carries no
-    tenant. When `create_if_absent` is true (publish paths), an unowned project
-    is bound to the caller's tenant and True is returned. Returns False on any
-    ownership mismatch; callers must raise.
+    No-ops when multi-tenancy is off or the caller carries no tenant. When
+    `create_if_absent` is True (publish paths), an unowned project is bound to
+    the caller's tenant instead of raising. Raises PermissionError on any
+    ownership mismatch; callers do not need to handle the bool.
     """
     if not MULTI_TENANT_ENABLED or identity.tenant_id is None:
-        return True
+        return
     if not identity.has_project(project_id):
-        return False
+        raise PermissionError("Permission denied")
     owner = await tenant_mgr.get_project_tenant(project_id)
     if owner is None:
         if create_if_absent:
             await tenant_mgr.add_project(identity.tenant_id, project_id)
-            return True
-        return False
-    return owner == identity.tenant_id
+            return
+        raise PermissionError("Permission denied")
+    if owner != identity.tenant_id:
+        raise PermissionError("Permission denied")

--- a/src/core/ownership.py
+++ b/src/core/ownership.py
@@ -1,30 +1,28 @@
 """Project→tenant ownership enforcement for authorized routes."""
 from __future__ import annotations
 
-from fastapi import HTTPException
-
 from src.core.identity import Identity
 from src.core.tenant_middleware import MULTI_TENANT_ENABLED
 
 
 async def check_project_access(
     identity: Identity, project_id: str, tenant_mgr, *, create_if_absent: bool
-) -> None:
-    """Enforce that `project_id` belongs to the caller's tenant.
+) -> bool:
+    """Return True when `project_id` is accessible to the caller's tenant.
 
-    No-op when multi-tenancy is off or the caller carries no tenant. When
-    `create_if_absent` is true (publish paths), an unowned project is bound to
-    the caller's tenant; otherwise an unowned or cross-tenant project is denied.
+    Returns True (allowed) when multi-tenancy is off or the caller carries no
+    tenant. When `create_if_absent` is true (publish paths), an unowned project
+    is bound to the caller's tenant and True is returned. Returns False on any
+    ownership mismatch; callers must raise.
     """
     if not MULTI_TENANT_ENABLED or identity.tenant_id is None:
-        return
+        return True
     if not identity.has_project(project_id):
-        raise HTTPException(status_code=403, detail="Forbidden")
+        return False
     owner = await tenant_mgr.get_project_tenant(project_id)
     if owner is None:
         if create_if_absent:
             await tenant_mgr.add_project(identity.tenant_id, project_id)
-            return
-        raise HTTPException(status_code=403, detail="Forbidden")
-    if owner != identity.tenant_id:
-        raise HTTPException(status_code=403, detail="Forbidden")
+            return True
+        return False
+    return owner == identity.tenant_id

--- a/src/core/ownership.py
+++ b/src/core/ownership.py
@@ -1,0 +1,30 @@
+"""Project→tenant ownership enforcement for authorized routes."""
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from src.core.identity import Identity
+from src.core.tenant_middleware import MULTI_TENANT_ENABLED
+
+
+async def check_project_access(
+    identity: Identity, project_id: str, tenant_mgr, *, create_if_absent: bool
+) -> None:
+    """Enforce that `project_id` belongs to the caller's tenant.
+
+    No-op when multi-tenancy is off or the caller carries no tenant. When
+    `create_if_absent` is true (publish paths), an unowned project is bound to
+    the caller's tenant; otherwise an unowned or cross-tenant project is denied.
+    """
+    if not MULTI_TENANT_ENABLED or identity.tenant_id is None:
+        return
+    if not identity.has_project(project_id):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    owner = await tenant_mgr.get_project_tenant(project_id)
+    if owner is None:
+        if create_if_absent:
+            await tenant_mgr.add_project(identity.tenant_id, project_id)
+            return
+        raise HTTPException(status_code=403, detail="Forbidden")
+    if owner != identity.tenant_id:
+        raise HTTPException(status_code=403, detail="Forbidden")

--- a/src/core/subscriptions.py
+++ b/src/core/subscriptions.py
@@ -10,8 +10,14 @@ from sqlalchemy import select
 
 from src.core.db_models import Subscription
 from src.core.tenant import DEFAULT_TENANT_ID
+from src.core.tenant_middleware import MULTI_TENANT_ENABLED
 
 logger = logging.getLogger(__name__)
+
+
+def _assert_sub_tenant(row, tenant_id):
+    if MULTI_TENANT_ENABLED and tenant_id is not None and row.tenant_id != tenant_id:
+        raise PermissionError("Permission denied")
 
 
 class SubscriptionService:
@@ -34,22 +40,24 @@ class SubscriptionService:
             await session.commit()
         return sub_id
 
-    async def get_bundle(self, subscription_id) -> dict:
+    async def get_bundle(self, subscription_id, *, tenant_id=None) -> dict:
         async with self.db.session() as session:
             row = (await session.execute(
                 select(Subscription).where(Subscription.subscription_id == subscription_id)
             )).scalar_one_or_none()
             if row is None:
                 raise KeyError(subscription_id)
+            _assert_sub_tenant(row, tenant_id)
             return row.bundle
 
-    async def delete(self, subscription_id) -> None:
+    async def delete(self, subscription_id, *, tenant_id=None) -> None:
         async with self.db.session() as session:
             row = (await session.execute(
                 select(Subscription).where(Subscription.subscription_id == subscription_id)
             )).scalar_one_or_none()
             # Idempotent: only commit when a row actually existed; absent id is a no-op.
             if row is not None:
+                _assert_sub_tenant(row, tenant_id)
                 await session.delete(row)
                 await session.commit()
 

--- a/src/web/routes.py
+++ b/src/web/routes.py
@@ -5,7 +5,10 @@ import asyncio
 import tiktoken
 from fastapi import APIRouter, Depends, Request, Form, Query
 from src.core.authz import require, public
+from src.core.identity import Identity
+from src.core.ownership import check_project_access
 from src.core.rbac import Permission
+from src.core.tenant import TenantManager
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from pathlib import Path
@@ -263,17 +266,20 @@ async def get_project_data(request: Request, project_id: str):
     return {"data": data_items}
 
 
-@router.get("/subscribe", dependencies=[Depends(require(Permission.QUERY_DATA))])
+@router.get("/subscribe")
 async def subscribe_to_updates(
     request: Request,
     project_id: str = Query(...),
     need: str = Query(...),
+    identity: Identity = Depends(require(Permission.QUERY_DATA)),
 ):
     """Stream a natural-language need as a live-updating context bundle over SSE.
 
     Backed by an ephemeral Subscription; the browser is a parallel consumer of the
     same reconcile pipeline the MCP bridge uses.
     """
+    tenant_mgr = TenantManager(request.app.state.db)
+    await check_project_access(identity, project_id, tenant_mgr, create_if_absent=False)
     engine = request.app.state.context_engine
     return StreamingResponse(
         stream_subscription_updates(engine, project_id, need),

--- a/src/web/routes.py
+++ b/src/web/routes.py
@@ -3,12 +3,12 @@
 import json
 import asyncio
 import tiktoken
-from fastapi import APIRouter, Depends, Request, Form, Query
-from src.core.authz import require, public
+from fastapi import APIRouter, Depends, HTTPException, Request, Form, Query
+from src.api.deps import get_tenant_manager
+from src.core.authz import require, public, get_identity
 from src.core.identity import Identity
 from src.core.ownership import check_project_access
 from src.core.rbac import Permission
-from src.core.tenant import TenantManager
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from pathlib import Path
@@ -266,20 +266,21 @@ async def get_project_data(request: Request, project_id: str):
     return {"data": data_items}
 
 
-@router.get("/subscribe")
+@router.get("/subscribe", dependencies=[Depends(require(Permission.QUERY_DATA))])
 async def subscribe_to_updates(
     request: Request,
     project_id: str = Query(...),
     need: str = Query(...),
-    identity: Identity = Depends(require(Permission.QUERY_DATA)),
+    identity: Identity = Depends(get_identity),
+    tenant_mgr=Depends(get_tenant_manager),
 ):
     """Stream a natural-language need as a live-updating context bundle over SSE.
 
     Backed by an ephemeral Subscription; the browser is a parallel consumer of the
     same reconcile pipeline the MCP bridge uses.
     """
-    tenant_mgr = TenantManager(request.app.state.db)
-    await check_project_access(identity, project_id, tenant_mgr, create_if_absent=False)
+    if not await check_project_access(identity, project_id, tenant_mgr, create_if_absent=False):
+        raise HTTPException(status_code=403, detail="Forbidden")
     engine = request.app.state.context_engine
     return StreamingResponse(
         stream_subscription_updates(engine, project_id, need),

--- a/src/web/routes.py
+++ b/src/web/routes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Form, Query
 from src.api.deps import get_tenant_manager
 from src.core.authz import require, public, get_identity
 from src.core.identity import Identity
-from src.core.ownership import check_project_access
+from src.core.ownership import ensure_project_access
 from src.core.rbac import Permission
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
@@ -279,8 +279,7 @@ async def subscribe_to_updates(
     Backed by an ephemeral Subscription; the browser is a parallel consumer of the
     same reconcile pipeline the MCP bridge uses.
     """
-    if not await check_project_access(identity, project_id, tenant_mgr, create_if_absent=False):
-        raise HTTPException(status_code=403, detail="Forbidden")
+    await ensure_project_access(identity, project_id, tenant_mgr, create_if_absent=False)
     engine = request.app.state.context_engine
     return StreamingResponse(
         stream_subscription_updates(engine, project_id, need),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,8 @@
 """Tests for authentication with PostgreSQL"""
 
 import pytest
-from src.core.auth import create_api_key, revoke_api_key
+from src.core.auth import create_api_key, list_api_keys, revoke_api_key
+from src.core.db_models import Tenant as TenantModel
 
 
 @pytest.mark.asyncio
@@ -75,3 +76,68 @@ async def test_revoke_nonexistent_key(db):
     """Test revoking a key that doesn't exist"""
     success = await revoke_api_key(db, "nonexistent_key_id")
     assert success is False
+
+
+async def _ensure_tenant(db, tenant_id: str) -> None:
+    async with db.session() as session:
+        from sqlalchemy import select
+        result = await session.execute(
+            select(TenantModel).where(TenantModel.tenant_id == tenant_id)
+        )
+        if result.scalar_one_or_none() is None:
+            session.add(TenantModel(tenant_id=tenant_id, name=tenant_id, plan="free"))
+
+
+@pytest.mark.asyncio
+async def test_list_api_keys_tenant_filter(db):
+    """list_api_keys with tenant_id returns only that tenant's keys"""
+    await _ensure_tenant(db, "t1")
+    await _ensure_tenant(db, "t2")
+
+    _, key_t1 = await create_api_key(db, "t1-key", tenant_id="t1")
+    _, key_t2 = await create_api_key(db, "t2-key", tenant_id="t2")
+
+    t1_keys = await list_api_keys(db, tenant_id="t1")
+    t1_ids = {k.key_id for k in t1_keys}
+    assert key_t1.key_id in t1_ids
+    assert key_t2.key_id not in t1_ids
+
+
+@pytest.mark.asyncio
+async def test_revoke_api_key_tenant_mismatch(db):
+    """revoke_api_key returns False when key belongs to a different tenant"""
+    await _ensure_tenant(db, "t1")
+    await _ensure_tenant(db, "t2")
+
+    _, key_t2 = await create_api_key(db, "t2-to-revoke", tenant_id="t2")
+
+    result = await revoke_api_key(db, key_t2.key_id, tenant_id="t1")
+    assert result is False
+
+    # Key must still exist
+    from sqlalchemy import select
+    from src.core.db_models import APIKey
+    async with db.session() as session:
+        row = await session.execute(
+            select(APIKey).where(APIKey.key_id == key_t2.key_id)
+        )
+        assert row.scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+async def test_revoke_api_key_tenant_match(db):
+    """revoke_api_key returns True and deletes the key when tenant matches"""
+    await _ensure_tenant(db, "t1")
+
+    _, key_t1 = await create_api_key(db, "t1-to-revoke", tenant_id="t1")
+
+    result = await revoke_api_key(db, key_t1.key_id, tenant_id="t1")
+    assert result is True
+
+    from sqlalchemy import select
+    from src.core.db_models import APIKey
+    async with db.session() as session:
+        row = await session.execute(
+            select(APIKey).where(APIKey.key_id == key_t1.key_id)
+        )
+        assert row.scalar_one_or_none() is None

--- a/tests/test_authz_matrix.py
+++ b/tests/test_authz_matrix.py
@@ -25,7 +25,9 @@ rather than explicitly constructing ASGITransport — both behave identically in
 this httpx version and the former is the idiomatic form used in the brief.
 """
 import pytest
+import httpx
 from httpx import AsyncClient
+from unittest.mock import AsyncMock, MagicMock
 
 from src.core import authz
 from src.core.authz import get_identity
@@ -41,12 +43,18 @@ def _identity(role: Role) -> Identity:
 def app_authed(monkeypatch):
     monkeypatch.setattr(authz, "auth_enabled", lambda: True)
     from main import app
+
+    mock_engine = MagicMock()
+    mock_engine.publish_data = AsyncMock(return_value="1")
+    app.state.context_engine = mock_engine
+    app.state.db = MagicMock()
+
     return app
 
 
 @pytest.mark.asyncio
 async def test_missing_key_is_401(app_authed):
-    async with AsyncClient(app=app_authed, base_url="http://t") as c:
+    async with AsyncClient(transport=httpx.ASGITransport(app=app_authed), base_url="http://t") as c:
         r = await c.post("/api/v1/data/publish", json={})
         assert r.status_code == 401
 
@@ -55,7 +63,7 @@ async def test_missing_key_is_401(app_authed):
 async def test_readonly_cannot_publish(app_authed):
     app_authed.dependency_overrides[get_identity] = lambda: _identity(Role.READONLY)
     try:
-        async with AsyncClient(app=app_authed, base_url="http://t") as c:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app_authed), base_url="http://t") as c:
             r = await c.post("/api/v1/data/publish",
                              json={"project_id": "p", "data_key": "k", "data": {}})
             assert r.status_code == 403
@@ -67,7 +75,7 @@ async def test_readonly_cannot_publish(app_authed):
 async def test_publisher_can_reach_publish(app_authed):
     app_authed.dependency_overrides[get_identity] = lambda: _identity(Role.PUBLISHER)
     try:
-        async with AsyncClient(app=app_authed, base_url="http://t") as c:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app_authed), base_url="http://t") as c:
             r = await c.post("/api/v1/data/publish",
                              json={"project_id": "p", "data_key": "k", "data": {}})
             assert r.status_code != 403  # authz passes (may 4xx/5xx on body/engine, not 403)
@@ -77,7 +85,7 @@ async def test_publisher_can_reach_publish(app_authed):
 
 @pytest.mark.asyncio
 async def test_legacy_api_alias_is_gone(app_authed):
-    async with AsyncClient(app=app_authed, base_url="http://t") as c:
+    async with AsyncClient(transport=httpx.ASGITransport(app=app_authed), base_url="http://t") as c:
         # /api/... (non-v1) should 404 now that the alias is removed
         r = await c.post("/api/data/publish", json={})
         assert r.status_code == 404

--- a/tests/test_mcp_subscription_tools.py
+++ b/tests/test_mcp_subscription_tools.py
@@ -1,7 +1,13 @@
 import json
 import pytest
+from sqlalchemy import text
+from unittest.mock import MagicMock
+
+from src.core import mcp_adapter
+from src.core import subscriptions as subscriptions_module
 from src.core.context_engine import ContextEngine
 from src.core.mcp_adapter import build_mcp_server
+from mcp.server.auth.middleware.auth_context import get_access_token
 
 
 @pytest.mark.asyncio
@@ -57,3 +63,53 @@ async def test_create_with_empty_needs(db, redis):
     bundle = await engine.subscriptions.get_bundle(sub_id)
     # No needs → empty bundle (nothing to match)
     assert bundle == {}
+
+
+@pytest.mark.asyncio
+async def test_multitenant_create_read_delete_lifecycle(db, redis, monkeypatch):
+    """Full create→get_bundle→delete lifecycle succeeds for a real-tenant caller.
+
+    Regression test for the bug where contex_create_subscription stored
+    tenant_id='default' regardless of the caller's token claims, causing
+    _assert_sub_tenant to raise PermissionError on subsequent read/delete.
+    """
+    tenant_id = "tenant-A"
+
+    async with db.session() as session:
+        await session.execute(
+            text("INSERT INTO tenants (tenant_id, name, is_active) VALUES (:tid, :name, true) ON CONFLICT DO NOTHING"),
+            {"tid": tenant_id, "name": tenant_id},
+        )
+        await session.execute(
+            text("INSERT INTO tenant_projects (tenant_id, project_id) VALUES (:tid, :pid) ON CONFLICT DO NOTHING"),
+            {"tid": tenant_id, "pid": "proj-mt"},
+        )
+        await session.commit()
+
+    fake_token = MagicMock()
+    fake_token.scopes = ["query_data"]
+    fake_token.claims = {"tenant_id": tenant_id, "projects": []}
+
+    monkeypatch.setattr(mcp_adapter, "auth_enabled", lambda: True)
+    monkeypatch.setattr(mcp_adapter, "get_access_token", lambda: fake_token)
+    monkeypatch.setattr(subscriptions_module, "MULTI_TENANT_ENABLED", True)
+
+    engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
+    await engine.initialize()
+    server, _ = build_mcp_server(engine)
+
+    created = json.loads((await server.call_tool("contex_create_subscription", {
+        "project_id": "proj-mt", "needs": ["auth config"], "top_k": 5,
+    })).content[0].text)
+    sub_id = created["subscription_id"]
+
+    bundle = await engine.subscriptions.get_bundle(sub_id, tenant_id=tenant_id)
+    assert bundle is not None
+
+    deleted = json.loads((await server.call_tool("contex_delete_subscription", {
+        "subscription_id": sub_id,
+    })).content[0].text)
+    assert deleted["deleted"] == sub_id
+
+    with pytest.raises(KeyError):
+        await engine.subscriptions.get_bundle(sub_id, tenant_id=tenant_id)

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -1,0 +1,72 @@
+import pytest
+from unittest.mock import AsyncMock
+from fastapi import HTTPException
+
+from src.core import ownership
+from src.core.ownership import check_project_access
+from src.core.identity import Identity
+from src.core.rbac import Permission
+
+
+def _ident(tenant_id, projects=()):
+    return Identity(key_id="k", scopes=frozenset({Permission.PUBLISH_DATA}),
+                    tenant_id=tenant_id, projects=tuple(projects), role=None)
+
+
+@pytest.mark.asyncio
+async def test_noop_when_multitenant_off(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", False)
+    mgr = AsyncMock()
+    await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    mgr.get_project_tenant.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_noop_when_identity_has_no_tenant(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock()
+    await check_project_access(_ident(None), "p1", mgr, create_if_absent=False)
+    mgr.get_project_tenant.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_read_denies_unowned_project(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock(); mgr.get_project_tenant.return_value = None
+    with pytest.raises(HTTPException) as e:
+        await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    assert e.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_read_denies_other_tenant_project(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock(); mgr.get_project_tenant.return_value = "t2"
+    with pytest.raises(HTTPException) as e:
+        await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    assert e.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_read_allows_owned_project(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock(); mgr.get_project_tenant.return_value = "t1"
+    await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+
+
+@pytest.mark.asyncio
+async def test_publish_binds_new_project(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock(); mgr.get_project_tenant.return_value = None
+    await check_project_access(_ident("t1"), "pnew", mgr, create_if_absent=True)
+    mgr.add_project.assert_awaited_once_with("t1", "pnew")
+
+
+@pytest.mark.asyncio
+async def test_key_project_scope_denies_out_of_scope(monkeypatch):
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+    mgr = AsyncMock()
+    with pytest.raises(HTTPException) as e:
+        await check_project_access(_ident("t1", projects=["allowed"]), "other", mgr, create_if_absent=True)
+    assert e.value.status_code == 403
+    mgr.get_project_tenant.assert_not_called()  # scope check short-circuits

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import AsyncMock
 
 from src.core import ownership
-from src.core.ownership import check_project_access
+from src.core.ownership import ensure_project_access
 from src.core.identity import Identity
 from src.core.rbac import Permission
 
@@ -16,8 +16,7 @@ def _ident(tenant_id, projects=()):
 async def test_noop_when_multitenant_off(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", False)
     mgr = AsyncMock()
-    result = await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
-    assert result is True
+    await ensure_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
     mgr.get_project_tenant.assert_not_called()
 
 
@@ -25,8 +24,7 @@ async def test_noop_when_multitenant_off(monkeypatch):
 async def test_noop_when_identity_has_no_tenant(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock()
-    result = await check_project_access(_ident(None), "p1", mgr, create_if_absent=False)
-    assert result is True
+    await ensure_project_access(_ident(None), "p1", mgr, create_if_absent=False)
     mgr.get_project_tenant.assert_not_called()
 
 
@@ -34,32 +32,30 @@ async def test_noop_when_identity_has_no_tenant(monkeypatch):
 async def test_read_denies_unowned_project(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock(); mgr.get_project_tenant.return_value = None
-    result = await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
-    assert result is False
+    with pytest.raises(PermissionError):
+        await ensure_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
 
 
 @pytest.mark.asyncio
 async def test_read_denies_other_tenant_project(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock(); mgr.get_project_tenant.return_value = "t2"
-    result = await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
-    assert result is False
+    with pytest.raises(PermissionError):
+        await ensure_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
 
 
 @pytest.mark.asyncio
 async def test_read_allows_owned_project(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock(); mgr.get_project_tenant.return_value = "t1"
-    result = await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
-    assert result is True
+    await ensure_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
 
 
 @pytest.mark.asyncio
 async def test_publish_binds_new_project(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock(); mgr.get_project_tenant.return_value = None
-    result = await check_project_access(_ident("t1"), "pnew", mgr, create_if_absent=True)
-    assert result is True
+    await ensure_project_access(_ident("t1"), "pnew", mgr, create_if_absent=True)
     mgr.add_project.assert_awaited_once_with("t1", "pnew")
 
 
@@ -67,6 +63,6 @@ async def test_publish_binds_new_project(monkeypatch):
 async def test_key_project_scope_denies_out_of_scope(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock()
-    result = await check_project_access(_ident("t1", projects=["allowed"]), "other", mgr, create_if_absent=True)
-    assert result is False
+    with pytest.raises(PermissionError):
+        await ensure_project_access(_ident("t1", projects=["allowed"]), "other", mgr, create_if_absent=True)
     mgr.get_project_tenant.assert_not_called()  # scope check short-circuits

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -1,6 +1,5 @@
 import pytest
 from unittest.mock import AsyncMock
-from fastapi import HTTPException
 
 from src.core import ownership
 from src.core.ownership import check_project_access
@@ -17,7 +16,8 @@ def _ident(tenant_id, projects=()):
 async def test_noop_when_multitenant_off(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", False)
     mgr = AsyncMock()
-    await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    result = await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    assert result is True
     mgr.get_project_tenant.assert_not_called()
 
 
@@ -25,7 +25,8 @@ async def test_noop_when_multitenant_off(monkeypatch):
 async def test_noop_when_identity_has_no_tenant(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock()
-    await check_project_access(_ident(None), "p1", mgr, create_if_absent=False)
+    result = await check_project_access(_ident(None), "p1", mgr, create_if_absent=False)
+    assert result is True
     mgr.get_project_tenant.assert_not_called()
 
 
@@ -33,32 +34,32 @@ async def test_noop_when_identity_has_no_tenant(monkeypatch):
 async def test_read_denies_unowned_project(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock(); mgr.get_project_tenant.return_value = None
-    with pytest.raises(HTTPException) as e:
-        await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
-    assert e.value.status_code == 403
+    result = await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    assert result is False
 
 
 @pytest.mark.asyncio
 async def test_read_denies_other_tenant_project(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock(); mgr.get_project_tenant.return_value = "t2"
-    with pytest.raises(HTTPException) as e:
-        await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
-    assert e.value.status_code == 403
+    result = await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    assert result is False
 
 
 @pytest.mark.asyncio
 async def test_read_allows_owned_project(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock(); mgr.get_project_tenant.return_value = "t1"
-    await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    result = await check_project_access(_ident("t1"), "p1", mgr, create_if_absent=False)
+    assert result is True
 
 
 @pytest.mark.asyncio
 async def test_publish_binds_new_project(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock(); mgr.get_project_tenant.return_value = None
-    await check_project_access(_ident("t1"), "pnew", mgr, create_if_absent=True)
+    result = await check_project_access(_ident("t1"), "pnew", mgr, create_if_absent=True)
+    assert result is True
     mgr.add_project.assert_awaited_once_with("t1", "pnew")
 
 
@@ -66,7 +67,6 @@ async def test_publish_binds_new_project(monkeypatch):
 async def test_key_project_scope_denies_out_of_scope(monkeypatch):
     monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
     mgr = AsyncMock()
-    with pytest.raises(HTTPException) as e:
-        await check_project_access(_ident("t1", projects=["allowed"]), "other", mgr, create_if_absent=True)
-    assert e.value.status_code == 403
+    result = await check_project_access(_ident("t1", projects=["allowed"]), "other", mgr, create_if_absent=True)
+    assert result is False
     mgr.get_project_tenant.assert_not_called()  # scope check short-circuits

--- a/tests/test_publish_route_provenance.py
+++ b/tests/test_publish_route_provenance.py
@@ -37,7 +37,7 @@ async def test_publish_route_stamps_provenance():
     # so we patch at src.core.metrics (the canonical location of the objects).
     chainable_hist = _chainable_histogram()
     with (
-        patch("src.api.routes.check_project_access", new=AsyncMock()),
+        patch("src.api.routes.ensure_project_access", new=AsyncMock()),
         patch("src.api.routes.audit_log", new=AsyncMock()),
         patch("src.api.routes.emit_webhook", new=AsyncMock()),
         patch("src.core.metrics.record_event_published", new=MagicMock()),

--- a/tests/test_publish_route_provenance.py
+++ b/tests/test_publish_route_provenance.py
@@ -30,12 +30,14 @@ async def test_publish_route_stamps_provenance():
     mock_engine = MagicMock()
     mock_engine.publish_data = AsyncMock(return_value="42")
     app.state.context_engine = mock_engine
+    app.state.db = MagicMock()
 
     # Patch post-publish side effects so they don't error in a bare app.
     # The route does lazy `from src.core.metrics import ...` inside the function body,
     # so we patch at src.core.metrics (the canonical location of the objects).
     chainable_hist = _chainable_histogram()
     with (
+        patch("src.api.routes.check_project_access", new=AsyncMock()),
         patch("src.api.routes.audit_log", new=AsyncMock()),
         patch("src.api.routes.emit_webhook", new=AsyncMock()),
         patch("src.core.metrics.record_event_published", new=MagicMock()),

--- a/tests/test_route_ownership.py
+++ b/tests/test_route_ownership.py
@@ -12,6 +12,7 @@ import pytest
 import httpx
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from httpx import AsyncClient
 
 from src.api.routes import router as api_router
@@ -34,6 +35,11 @@ def _identity(tenant_id, projects=()):
 def _build_app(identity: Identity):
     """Build a minimal FastAPI app with the API router and a fake engine."""
     app = FastAPI()
+
+    @app.exception_handler(PermissionError)
+    async def _permission_denied_handler(request, exc):
+        return JSONResponse(status_code=403, content={"detail": "Forbidden"})
+
     app.include_router(api_router, prefix="/api/v1")
 
     mock_engine = MagicMock()
@@ -46,7 +52,7 @@ def _build_app(identity: Identity):
     mock_engine._truncate_matches = MagicMock(return_value={})
     app.state.context_engine = mock_engine
 
-    # Stub db — the TenantManager constructor needs it but we'll patch check_project_access
+    # Stub db — the TenantManager constructor needs it but we'll patch ensure_project_access
     app.state.db = MagicMock()
 
     app.dependency_overrides[get_identity] = lambda: identity

--- a/tests/test_route_ownership.py
+++ b/tests/test_route_ownership.py
@@ -1,0 +1,228 @@
+"""Tests: project→tenant ownership enforcement on data and cleanup routes.
+
+With MULTI_TENANT_ENABLED=True and AUTH_ENABLED=True:
+- tenant A gets 403 on a project owned by tenant B
+- tenant A gets non-403 on its own project
+- publish to a new project binds it (no 403)
+
+With MULTI_TENANT_ENABLED=False: all pass unchanged.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import FastAPI, Request
+from httpx import AsyncClient
+
+from src.api.routes import router as api_router
+from src.core import authz, ownership
+from src.core.authz import get_identity
+from src.core.identity import Identity
+from src.core.rbac import Permission
+
+
+def _identity(tenant_id, projects=()):
+    return Identity(
+        key_id="k",
+        scopes=frozenset(Permission),
+        tenant_id=tenant_id,
+        projects=tuple(projects),
+        role=None,
+    )
+
+
+def _build_app(identity: Identity):
+    """Build a minimal FastAPI app with the API router and a fake engine."""
+    app = FastAPI()
+    app.include_router(api_router, prefix="/api/v1")
+
+    mock_engine = MagicMock()
+    mock_engine.publish_data = AsyncMock(return_value="1")
+    mock_engine.query_project_data = AsyncMock(return_value=[])
+    mock_engine.event_store = MagicMock()
+    mock_engine.event_store.get_events_since = AsyncMock(return_value=[])
+    mock_engine.semantic_matcher = MagicMock()
+    mock_engine.semantic_matcher.get_registered_data = AsyncMock(return_value=[])
+    mock_engine._truncate_matches = MagicMock(return_value={})
+    app.state.context_engine = mock_engine
+
+    # Stub db — the TenantManager constructor needs it but we'll patch check_project_access
+    app.state.db = MagicMock()
+
+    app.dependency_overrides[get_identity] = lambda: identity
+    return app
+
+
+# ─── Multi-tenant ON ────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_data_endpoint_403_cross_tenant(monkeypatch):
+    """With multi-tenant on, tenant A gets 403 on tenant B's project."""
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    identity_a = _identity("tenant-a")
+    app = _build_app(identity_a)
+
+    # TenantManager will say the project belongs to tenant-b
+    mock_mgr = AsyncMock()
+    mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
+
+    with patch("src.api.routes.get_tenant_manager", return_value=mock_mgr):
+        async with AsyncClient(app=app, base_url="http://test") as c:
+            resp = await c.get("/api/v1/projects/project-b/data")
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_data_endpoint_200_own_project(monkeypatch):
+    """With multi-tenant on, tenant A gets 200 on its own project."""
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    identity_a = _identity("tenant-a")
+    app = _build_app(identity_a)
+
+    mock_mgr = AsyncMock()
+    mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-a")
+
+    with (
+        patch("src.api.routes.get_tenant_manager", return_value=mock_mgr),
+        patch("src.api.routes.audit_log", new=AsyncMock()),
+    ):
+        async with AsyncClient(app=app, base_url="http://test") as c:
+            resp = await c.get("/api/v1/projects/project-a/data")
+
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_publish_new_project_binds_to_tenant(monkeypatch):
+    """With multi-tenant on, publishing to an unowned project binds it (no 403)."""
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    identity_a = _identity("tenant-a")
+    app = _build_app(identity_a)
+
+    mock_mgr = AsyncMock()
+    mock_mgr.get_project_tenant = AsyncMock(return_value=None)
+    mock_mgr.add_project = AsyncMock(return_value="tenant-a:project:new-proj")
+
+    chainable_hist = MagicMock()
+    chainable_hist.labels.return_value = MagicMock()
+    chainable_hist.labels.return_value.observe = MagicMock()
+
+    with (
+        patch("src.api.routes.get_tenant_manager", return_value=mock_mgr),
+        patch("src.api.routes.audit_log", new=AsyncMock()),
+        patch("src.api.routes.emit_webhook", new=AsyncMock()),
+        patch("src.core.metrics.record_event_published", new=MagicMock()),
+        patch("src.core.metrics.publish_duration_seconds", new=chainable_hist),
+    ):
+        async with AsyncClient(app=app, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/data/publish",
+                json={"project_id": "new-proj", "data_key": "k", "data": {"x": 1}},
+            )
+
+    assert resp.status_code == 200
+    mock_mgr.add_project.assert_awaited_once_with("tenant-a", "new-proj")
+
+
+@pytest.mark.asyncio
+async def test_events_endpoint_403_cross_tenant(monkeypatch):
+    """With multi-tenant on, tenant A gets 403 on tenant B's events."""
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    identity_a = _identity("tenant-a")
+    app = _build_app(identity_a)
+
+    mock_mgr = AsyncMock()
+    mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
+
+    with patch("src.api.routes.get_tenant_manager", return_value=mock_mgr):
+        async with AsyncClient(app=app, base_url="http://test") as c:
+            resp = await c.get("/api/v1/projects/project-b/events")
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_cleanup_project_403_cross_tenant(monkeypatch):
+    """With multi-tenant on, tenant A gets 403 on cleanup of tenant B's project."""
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    identity_a = _identity("tenant-a")
+    app = _build_app(identity_a)
+
+    mock_mgr = AsyncMock()
+    mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
+
+    with patch("src.api.routes.get_tenant_manager", return_value=mock_mgr):
+        async with AsyncClient(app=app, base_url="http://test") as c:
+            resp = await c.post("/api/v1/admin/cleanup/project-b")
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_retention_stats_403_cross_tenant(monkeypatch):
+    """With multi-tenant on, tenant A gets 403 on retention stats for tenant B's project."""
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    identity_a = _identity("tenant-a")
+    app = _build_app(identity_a)
+
+    mock_mgr = AsyncMock()
+    mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
+
+    with patch("src.api.routes.get_tenant_manager", return_value=mock_mgr):
+        async with AsyncClient(app=app, base_url="http://test") as c:
+            resp = await c.get("/api/v1/admin/retention/project-b")
+
+    assert resp.status_code == 403
+
+
+# ─── Multi-tenant OFF ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_data_endpoint_passes_when_multitenant_off(monkeypatch):
+    """With multi-tenant off, cross-tenant calls are not 403."""
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", False)
+
+    identity_a = _identity("tenant-a")
+    app = _build_app(identity_a)
+
+    mock_mgr = AsyncMock()
+    mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
+
+    with (
+        patch("src.api.routes.get_tenant_manager", return_value=mock_mgr),
+        patch("src.api.routes.audit_log", new=AsyncMock()),
+    ):
+        async with AsyncClient(app=app, base_url="http://test") as c:
+            resp = await c.get("/api/v1/projects/project-b/data")
+
+    assert resp.status_code != 403
+
+
+@pytest.mark.asyncio
+async def test_cleanup_passes_when_multitenant_off(monkeypatch):
+    """With multi-tenant off, cleanup of any project is not 403."""
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", False)
+
+    identity_a = _identity("tenant-a")
+    app = _build_app(identity_a)
+
+    mock_mgr = AsyncMock()
+    mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
+
+    with (
+        patch("src.api.routes.get_tenant_manager", return_value=mock_mgr),
+        patch("src.core.retention.get_retention_manager_from_env") as mock_ret,
+    ):
+        mock_ret_mgr = AsyncMock()
+        mock_ret_mgr.cleanup_project = AsyncMock(return_value={"project_id": "project-b", "events_deleted": 0, "agents_cleaned": 0})
+        mock_ret.return_value = mock_ret_mgr
+        async with AsyncClient(app=app, base_url="http://test") as c:
+            resp = await c.post("/api/v1/admin/cleanup/project-b")
+
+    assert resp.status_code != 403

--- a/tests/test_route_ownership.py
+++ b/tests/test_route_ownership.py
@@ -227,3 +227,59 @@ async def test_cleanup_passes_when_multitenant_off(monkeypatch):
             resp = await c.post("/api/v1/admin/cleanup/project-b")
 
     assert resp.status_code != 403
+
+
+# ─── Batch publish ownership ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_batch_publish_cross_tenant_is_403(monkeypatch):
+    """With multi-tenant on, a batch containing a cross-tenant project returns 403 (not 200-with-failed)."""
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    identity_a = _identity("tenant-a")
+    app = _build_app(identity_a)
+
+    mock_mgr = AsyncMock()
+    mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
+
+    with patch("src.api.routes.get_tenant_manager", return_value=mock_mgr):
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/batch/publish",
+                json=[{"project_id": "proj-b", "data_key": "k1", "data": {"x": 1}}],
+            )
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_batch_publish_own_tenant_succeeds(monkeypatch):
+    """With multi-tenant on, a batch entirely within tenant-A completes successfully."""
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    identity_a = _identity("tenant-a")
+    app = _build_app(identity_a)
+
+    mock_mgr = AsyncMock()
+    mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-a")
+
+    chainable_hist = MagicMock()
+    chainable_hist.labels.return_value = MagicMock()
+    chainable_hist.labels.return_value.observe = MagicMock()
+
+    with (
+        patch("src.api.routes.get_tenant_manager", return_value=mock_mgr),
+        patch("src.core.metrics.record_event_published", new=MagicMock()),
+        patch("src.core.metrics.publish_duration_seconds", new=chainable_hist),
+    ):
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v1/batch/publish",
+                json=[{"project_id": "proj-a", "data_key": "k1", "data": {"x": 1}}],
+            )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["successful"] == 1
+    assert body["failed"] == 0

--- a/tests/test_route_ownership.py
+++ b/tests/test_route_ownership.py
@@ -9,6 +9,7 @@ With MULTI_TENANT_ENABLED=False: all pass unchanged.
 """
 
 import pytest
+import httpx
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import FastAPI, Request
 from httpx import AsyncClient
@@ -67,7 +68,7 @@ async def test_data_endpoint_403_cross_tenant(monkeypatch):
     mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
 
     with patch("src.api.routes.get_tenant_manager", return_value=mock_mgr):
-        async with AsyncClient(app=app, base_url="http://test") as c:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.get("/api/v1/projects/project-b/data")
 
     assert resp.status_code == 403
@@ -88,7 +89,7 @@ async def test_data_endpoint_200_own_project(monkeypatch):
         patch("src.api.routes.get_tenant_manager", return_value=mock_mgr),
         patch("src.api.routes.audit_log", new=AsyncMock()),
     ):
-        async with AsyncClient(app=app, base_url="http://test") as c:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.get("/api/v1/projects/project-a/data")
 
     assert resp.status_code == 200
@@ -117,7 +118,7 @@ async def test_publish_new_project_binds_to_tenant(monkeypatch):
         patch("src.core.metrics.record_event_published", new=MagicMock()),
         patch("src.core.metrics.publish_duration_seconds", new=chainable_hist),
     ):
-        async with AsyncClient(app=app, base_url="http://test") as c:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.post(
                 "/api/v1/data/publish",
                 json={"project_id": "new-proj", "data_key": "k", "data": {"x": 1}},
@@ -139,7 +140,7 @@ async def test_events_endpoint_403_cross_tenant(monkeypatch):
     mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
 
     with patch("src.api.routes.get_tenant_manager", return_value=mock_mgr):
-        async with AsyncClient(app=app, base_url="http://test") as c:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.get("/api/v1/projects/project-b/events")
 
     assert resp.status_code == 403
@@ -157,7 +158,7 @@ async def test_cleanup_project_403_cross_tenant(monkeypatch):
     mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
 
     with patch("src.api.routes.get_tenant_manager", return_value=mock_mgr):
-        async with AsyncClient(app=app, base_url="http://test") as c:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.post("/api/v1/admin/cleanup/project-b")
 
     assert resp.status_code == 403
@@ -175,7 +176,7 @@ async def test_retention_stats_403_cross_tenant(monkeypatch):
     mock_mgr.get_project_tenant = AsyncMock(return_value="tenant-b")
 
     with patch("src.api.routes.get_tenant_manager", return_value=mock_mgr):
-        async with AsyncClient(app=app, base_url="http://test") as c:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.get("/api/v1/admin/retention/project-b")
 
     assert resp.status_code == 403
@@ -198,7 +199,7 @@ async def test_data_endpoint_passes_when_multitenant_off(monkeypatch):
         patch("src.api.routes.get_tenant_manager", return_value=mock_mgr),
         patch("src.api.routes.audit_log", new=AsyncMock()),
     ):
-        async with AsyncClient(app=app, base_url="http://test") as c:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.get("/api/v1/projects/project-b/data")
 
     assert resp.status_code != 403
@@ -222,7 +223,7 @@ async def test_cleanup_passes_when_multitenant_off(monkeypatch):
         mock_ret_mgr = AsyncMock()
         mock_ret_mgr.cleanup_project = AsyncMock(return_value={"project_id": "project-b", "events_deleted": 0, "agents_cleaned": 0})
         mock_ret.return_value = mock_ret_mgr
-        async with AsyncClient(app=app, base_url="http://test") as c:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.post("/api/v1/admin/cleanup/project-b")
 
     assert resp.status_code != 403

--- a/tests/test_sandbox_watch.py
+++ b/tests/test_sandbox_watch.py
@@ -5,13 +5,14 @@ from pathlib import Path
 import pytest
 
 from src.core.context_engine import ContextEngine
+from src.core.identity import ANONYMOUS_IDENTITY
 from src.core.models import DataPublishEvent
 from src.web.routes import project_stats, sandbox_home, subscribe_to_updates
 
 
-def _request_with(engine):
+def _request_with(engine, db=None):
     return types.SimpleNamespace(
-        app=types.SimpleNamespace(state=types.SimpleNamespace(context_engine=engine))
+        app=types.SimpleNamespace(state=types.SimpleNamespace(context_engine=engine, db=db))
     )
 
 
@@ -19,7 +20,7 @@ def _request_with(engine):
 async def test_sandbox_home_renders(db, redis):
     engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
     await engine.initialize()
-    resp = await sandbox_home(_request_with(engine))
+    resp = await sandbox_home(_request_with(engine, db))
     assert resp.template.name == "sandbox.html"
 
 
@@ -27,7 +28,12 @@ async def test_sandbox_home_renders(db, redis):
 async def test_subscribe_returns_event_stream(db, redis):
     engine = ContextEngine(db=db, redis=redis, similarity_threshold=0.1, max_matches=10)
     await engine.initialize()
-    resp = await subscribe_to_updates(_request_with(engine), project_id="p", need="database connection settings")
+    resp = await subscribe_to_updates(
+        _request_with(engine, db),
+        project_id="p",
+        need="database connection settings",
+        identity=ANONYMOUS_IDENTITY,
+    )
     assert resp.media_type == "text/event-stream"
     assert resp.headers["Cache-Control"] == "no-cache"
 

--- a/tests/test_subscription_ownership.py
+++ b/tests/test_subscription_ownership.py
@@ -1,0 +1,108 @@
+"""Subscription tenant ownership enforcement tests (#42, #73)."""
+import pytest
+from sqlalchemy import select, text
+
+from src.core.db_models import Subscription
+from src.core.subscriptions import SubscriptionService
+from src.core.tenant import DEFAULT_TENANT_ID
+
+
+class _StubMatcher:
+    async def match(self, project_id, needs, metadata=None, top_k=None, threshold=None):
+        return {n: [{"data_key": "k", "similarity": 0.9, "data": {}, "description": "d"}] for n in needs}
+
+
+async def _ensure_tenant(db, tenant_id):
+    async with db.session() as session:
+        exists = (await session.execute(
+            text("SELECT 1 FROM tenants WHERE tenant_id = :tid"),
+            {"tid": tenant_id},
+        )).scalar_one_or_none()
+        if not exists:
+            await session.execute(
+                text("INSERT INTO tenants (tenant_id, name, is_active) VALUES (:tid, :name, true)"),
+                {"tid": tenant_id, "name": tenant_id},
+            )
+            await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_cross_tenant_raises(db, redis, monkeypatch):
+    monkeypatch.setattr("src.core.subscriptions.MULTI_TENANT_ENABLED", True)
+    await _ensure_tenant(db, "t1")
+    await _ensure_tenant(db, "t2")
+
+    svc = SubscriptionService(db, _StubMatcher(), redis)
+    sub_id = await svc.create("p1", ["need1"], tenant_id="t2")
+
+    with pytest.raises(PermissionError):
+        await svc.get_bundle(sub_id, tenant_id="t1")
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_same_tenant_returns_bundle(db, redis, monkeypatch):
+    monkeypatch.setattr("src.core.subscriptions.MULTI_TENANT_ENABLED", True)
+    await _ensure_tenant(db, "t1")
+
+    svc = SubscriptionService(db, _StubMatcher(), redis)
+    sub_id = await svc.create("p1", ["need1"], tenant_id="t1")
+
+    bundle = await svc.get_bundle(sub_id, tenant_id="t1")
+    assert "need1" in bundle
+
+
+@pytest.mark.asyncio
+async def test_delete_cross_tenant_raises_and_sub_remains(db, redis, monkeypatch):
+    monkeypatch.setattr("src.core.subscriptions.MULTI_TENANT_ENABLED", True)
+    await _ensure_tenant(db, "t1")
+    await _ensure_tenant(db, "t2")
+
+    svc = SubscriptionService(db, _StubMatcher(), redis)
+    sub_id = await svc.create("p1", ["need1"], tenant_id="t2")
+
+    with pytest.raises(PermissionError):
+        await svc.delete(sub_id, tenant_id="t1")
+
+    async with db.session() as session:
+        row = (await session.execute(
+            select(Subscription).where(Subscription.subscription_id == sub_id)
+        )).scalar_one_or_none()
+    assert row is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_same_tenant_succeeds(db, redis, monkeypatch):
+    monkeypatch.setattr("src.core.subscriptions.MULTI_TENANT_ENABLED", True)
+    await _ensure_tenant(db, "t1")
+
+    svc = SubscriptionService(db, _StubMatcher(), redis)
+    sub_id = await svc.create("p1", ["need1"], tenant_id="t1")
+
+    await svc.delete(sub_id, tenant_id="t1")
+
+    async with db.session() as session:
+        row = (await session.execute(
+            select(Subscription).where(Subscription.subscription_id == sub_id)
+        )).scalar_one_or_none()
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_multi_tenant_disabled_cross_tenant_is_noop(db, redis, monkeypatch):
+    monkeypatch.setattr("src.core.subscriptions.MULTI_TENANT_ENABLED", False)
+    await _ensure_tenant(db, "t1")
+    await _ensure_tenant(db, "t2")
+
+    svc = SubscriptionService(db, _StubMatcher(), redis)
+    sub_id = await svc.create("p1", ["need1"], tenant_id="t2")
+
+    bundle = await svc.get_bundle(sub_id, tenant_id="t1")
+    assert "need1" in bundle
+
+    await svc.delete(sub_id, tenant_id="t1")
+
+    async with db.session() as session:
+        row = (await session.execute(
+            select(Subscription).where(Subscription.subscription_id == sub_id)
+        )).scalar_one_or_none()
+    assert row is None

--- a/tests/test_tenant_isolation.py
+++ b/tests/test_tenant_isolation.py
@@ -248,7 +248,7 @@ async def test_subscription_cross_tenant_denied_at_service(db, redis, monkeypatc
 async def test_sandbox_subscribe_cross_tenant_is_403(db, monkeypatch):
     """/sandbox/subscribe returns 403 for cross-tenant project before SSE starts.
 
-    The ownership check (check_project_access) runs synchronously before the
+    The ownership check (ensure_project_access) runs synchronously before the
     StreamingResponse generator is entered, so a 403 is returned immediately
     without hanging on SSE.
     """

--- a/tests/test_tenant_isolation.py
+++ b/tests/test_tenant_isolation.py
@@ -1,0 +1,298 @@
+# tests/test_tenant_isolation.py
+"""End-to-end multi-tenant isolation matrix.
+
+Proves that the ownership checks actually isolate tenants at the HTTP and
+service layers, and that isolation is a no-op when MULTI_TENANT_ENABLED is off.
+
+Transport: httpx.AsyncClient(transport=httpx.ASGITransport(app=app), ...) —
+no lifespan runs; app.state.db is wired in each test that needs real DB access.
+Ownership and auth checks run before any handler body that needs the engine,
+so 403s are delivered without requiring Redis / context engine init.
+"""
+import hashlib
+import secrets
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from sqlalchemy import text
+
+from main import app
+from src.core import authz, ownership
+from src.core.authz import get_identity
+from src.core.identity import Identity
+from src.core.rbac import Permission, Role, expand_role
+from src.core.subscriptions import SubscriptionService
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _admin_identity(tenant_id: str) -> Identity:
+    """Full-admin identity scoped to tenant_id (all permissions; projects=() = all)."""
+    return Identity(
+        key_id="k",
+        scopes=expand_role(Role.ADMIN),
+        tenant_id=tenant_id,
+        projects=(),
+        role=Role.ADMIN,
+    )
+
+
+async def _ensure_tenant(db, tenant_id: str) -> None:
+    async with db.session() as session:
+        exists = (await session.execute(
+            text("SELECT 1 FROM tenants WHERE tenant_id = :tid"),
+            {"tid": tenant_id},
+        )).scalar_one_or_none()
+        if not exists:
+            await session.execute(
+                text(
+                    "INSERT INTO tenants (tenant_id, name, plan, quotas, settings, metadata, is_active)"
+                    " VALUES (:tid, :name, 'enterprise', '{}', '{}', '{}', true)"
+                ),
+                {"tid": tenant_id, "name": tenant_id},
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO tenant_usage (tenant_id, projects_count, agents_count,"
+                    " api_keys_count, events_this_month, storage_used_mb)"
+                    " VALUES (:tid, 0, 0, 0, 0, 0.0)"
+                    " ON CONFLICT DO NOTHING"
+                ),
+                {"tid": tenant_id},
+            )
+            await session.commit()
+
+
+async def _seed_tenant_project(db, tenant_id: str, project_id: str) -> None:
+    async with db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO tenant_projects (tenant_id, project_id)"
+                " VALUES (:tid, :pid) ON CONFLICT DO NOTHING"
+            ),
+            {"tid": tenant_id, "pid": project_id},
+        )
+        await session.commit()
+
+
+def _stub_context_engine() -> MagicMock:
+    """Minimal stub so handler bodies after the ownership check don't AttributeError."""
+    engine = MagicMock()
+    engine.semantic_matcher = MagicMock()
+    engine.semantic_matcher.get_registered_data = AsyncMock(return_value=[])
+    engine.publish_data = AsyncMock(return_value="1")
+    engine.event_store = MagicMock()
+    engine.event_store.get_events_since = AsyncMock(return_value=[])
+    return engine
+
+
+async def _seed_api_key(db, key_id: str, tenant_id: str) -> None:
+    """Insert a minimal api_keys row for tenant_id (no real hash needed)."""
+    async with db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO api_keys (key_id, key_hash, name, prefix, scopes, tenant_id)"
+                " VALUES (:kid, :hash, :name, 'ck_tst', '{}', :tid)"
+            ),
+            {
+                "kid": key_id,
+                "hash": hashlib.sha256(secrets.token_bytes(16)).hexdigest(),
+                "name": f"key-{key_id}",
+                "tid": tenant_id,
+            },
+        )
+        await session.commit()
+
+
+# ── Case 1: cross-tenant project data → 403; own project → not 403 ─────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_project_data_is_403(db, monkeypatch):
+    """tenant-A identity gets 403 on tenant-B's project."""
+    monkeypatch.setattr(authz, "auth_enabled", lambda: True)
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    await _ensure_tenant(db, "tenant-A")
+    await _ensure_tenant(db, "tenant-B")
+    await _seed_tenant_project(db, "tenant-A", "proj-a")
+    await _seed_tenant_project(db, "tenant-B", "proj-b")
+
+    app.state.db = db
+    app.dependency_overrides[get_identity] = lambda: _admin_identity("tenant-A")
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.get("/api/v1/projects/proj-b/data")
+        assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_own_project_data_is_not_403(db, monkeypatch):
+    """tenant-A identity gets non-403 on its own project."""
+    monkeypatch.setattr(authz, "auth_enabled", lambda: True)
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    await _ensure_tenant(db, "tenant-A")
+    await _seed_tenant_project(db, "tenant-A", "proj-a")
+
+    app.state.db = db
+    app.state.context_engine = _stub_context_engine()
+    app.dependency_overrides[get_identity] = lambda: _admin_identity("tenant-A")
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.get("/api/v1/projects/proj-a/data")
+        assert r.status_code != 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Case 2: GET /auth/keys returns only caller's tenant keys ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_keys_scoped_to_caller_tenant(db, monkeypatch):
+    """GET /auth/keys returns only tenant-A's keys when called as tenant-A."""
+    monkeypatch.setattr(authz, "auth_enabled", lambda: True)
+
+    await _ensure_tenant(db, "tenant-A")
+    await _ensure_tenant(db, "tenant-B")
+    await _seed_api_key(db, "key-a1", "tenant-A")
+    await _seed_api_key(db, "key-a2", "tenant-A")
+    await _seed_api_key(db, "key-b1", "tenant-B")
+
+    app.state.db = db
+    app.dependency_overrides[get_identity] = lambda: _admin_identity("tenant-A")
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.get("/api/v1/auth/keys")
+        assert r.status_code == 200
+        ids = {k["key_id"] for k in r.json()}
+        assert "key-a1" in ids
+        assert "key-a2" in ids
+        assert "key-b1" not in ids
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Case 3: publish to new project → binds to tenant-A ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_publish_new_project_binds_to_tenant_a(db, monkeypatch):
+    """Publishing to an unowned project binds it to the caller's tenant."""
+    monkeypatch.setattr(authz, "auth_enabled", lambda: True)
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    await _ensure_tenant(db, "tenant-A")
+    # proj-new is intentionally absent from tenant_projects
+
+    app.state.db = db
+    app.state.context_engine = _stub_context_engine()
+    app.dependency_overrides[get_identity] = lambda: _admin_identity("tenant-A")
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.post(
+                "/api/v1/data/publish",
+                json={"project_id": "proj-new", "data_key": "dk1", "data": {"x": 1}},
+            )
+        # Ownership auto-binding happens; handler may 500 if engine isn't full, but not 403.
+        assert r.status_code != 403
+
+        # Assert the tenant_projects row was created for tenant-A.
+        async with db.session() as session:
+            row = (await session.execute(
+                text(
+                    "SELECT tenant_id FROM tenant_projects"
+                    " WHERE project_id = 'proj-new'"
+                )
+            )).first()
+        assert row is not None and row[0] == "tenant-A"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Case 4: subscription ownership at service layer ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_subscription_cross_tenant_denied_at_service(db, redis, monkeypatch):
+    """SubscriptionService.get_bundle raises PermissionError for cross-tenant access."""
+    monkeypatch.setattr("src.core.subscriptions.MULTI_TENANT_ENABLED", True)
+
+    await _ensure_tenant(db, "tenant-A")
+    await _ensure_tenant(db, "tenant-B")
+
+    class _StubMatcher:
+        async def match(self, project_id, needs, top_k=None, threshold=None):
+            return {n: [] for n in needs}
+
+    svc = SubscriptionService(db, _StubMatcher(), redis)
+    sub_id = await svc.create("proj-b", ["some need"], tenant_id="tenant-B")
+
+    with pytest.raises(PermissionError):
+        await svc.get_bundle(sub_id, tenant_id="tenant-A")
+
+
+# ── Case 5: /sandbox/subscribe cross-tenant → 403 ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sandbox_subscribe_cross_tenant_is_403(db, monkeypatch):
+    """/sandbox/subscribe returns 403 for cross-tenant project before SSE starts.
+
+    The ownership check (check_project_access) runs synchronously before the
+    StreamingResponse generator is entered, so a 403 is returned immediately
+    without hanging on SSE.
+    """
+    monkeypatch.setattr(authz, "auth_enabled", lambda: True)
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", True)
+
+    await _ensure_tenant(db, "tenant-A")
+    await _ensure_tenant(db, "tenant-B")
+    await _seed_tenant_project(db, "tenant-B", "proj-b-sub")
+
+    app.state.db = db
+    app.dependency_overrides[get_identity] = lambda: _admin_identity("tenant-A")
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.get(
+                "/sandbox/subscribe",
+                params={"project_id": "proj-b-sub", "need": "auth tokens"},
+            )
+        assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Case 6: isolation OFF → cross-tenant call is NOT 403 ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_data_not_403_when_isolation_off(db, monkeypatch):
+    """With MULTI_TENANT_ENABLED=False, cross-tenant project access is not blocked."""
+    monkeypatch.setattr(authz, "auth_enabled", lambda: True)
+    monkeypatch.setattr(ownership, "MULTI_TENANT_ENABLED", False)
+
+    await _ensure_tenant(db, "tenant-A")
+    await _ensure_tenant(db, "tenant-B")
+    await _seed_tenant_project(db, "tenant-B", "proj-b-off")
+
+    app.state.db = db
+    app.state.context_engine = _stub_context_engine()
+    app.dependency_overrides[get_identity] = lambda: _admin_identity("tenant-A")
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.get("/api/v1/projects/proj-b-off/data")
+        assert r.status_code != 403
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Description

**Tier 0 ownership enforcement (Wave D fast-follow, PR B of 2).** Builds on the merged always-a-tenant foundation (#130) to close the tenant/project IDOR gaps: a request can only touch projects, keys, and subscriptions that belong to the caller's tenant. Every check is a **no-op unless `MULTI_TENANT_ENABLED` is on and the caller carries a tenant** — single-tenant and auth-off/demo deployments are unaffected.

Design doc: `docs/superpowers/plans/2026-09-07-tier0-ownership-batch1.md`. Requires #130 (merged).

## Type of Change

- [x] Bug fix (closes IDOR/authorization gaps)
- [x] New feature (per-route/tool tenant ownership enforcement)

## Related Issues

Closes #42, #43, #54, #55, #73
Also removes the dead `require_admin_permission` guard left over from #39, and the sandbox data-path (#40 REST remnant).

## Changes Made

- **`check_project_access` helper** (`src/core/ownership.py`): gated project→tenant ownership — read paths deny unowned/cross-tenant (403); publish paths auto-bind a new project to the caller's tenant. Resolves ownership via `TenantManager.get_project_tenant` (the `tenant_projects` mapping).
- **#54 / #55 — data & cleanup routes** (`src/api/routes.py`): publish/upload/import/batch auto-bind; query/events/data and admin cleanup/retention deny cross-tenant.
- **#43 — API keys** (`src/api/routes.py`, `src/core/auth.py`): `GET /auth/keys` lists only the caller's tenant; `DELETE` refuses cross-tenant (404, no info leak); `POST` stamps the creator's tenant.
- **`/sandbox/subscribe`**: project-scope check before the SSE stream opens.
- **#42 / #73 — subscriptions** (`src/core/subscriptions.py`, `src/core/mcp_adapter.py`): `get_bundle`/`delete` verify the subscription's tenant (raise before returning/deleting on mismatch); the MCP tools (`contex_create_subscription`/`contex_delete_subscription`/`read_subscription`) stamp/verify tenant from the token claims, so the create→read→delete lifecycle is tenant-consistent.
- **Removed the dead `require_admin_permission`** (#39 remnant, ~28 sites across tenant/webhook/service-account/audit routers) — each route is already gated by `require(Permission.MANAGE_*/VIEW_*)`.

## Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Tested edge cases

Full `tests/` suite: **464 passed, 0 failed**. New: `tests/test_ownership.py`, `tests/test_subscription_ownership.py`, and `tests/test_tenant_isolation.py` — an end-to-end matrix proving cross-tenant project data → 403, key listing scoped, publish auto-bind, subscription cross-tenant denial, sandbox 403, **and** that with `MULTI_TENANT_ENABLED=false` the same cross-tenant calls are *not* denied (isolation is genuinely toggled, not always-on). A multi-tenant MCP create→read→delete lifecycle test guards the create-tenant-stamping path. (~6 `sdk/python/tests` failures are pre-existing/unrelated.)

## Checklist

- [x] Self-review + per-task review of each change; whole-branch review (caught and fixed a create-subscription tenant-stamping gap)
- [x] Docs updated (plan committed)
- [x] No new warnings
- [x] Tests added proving cross-tenant denial and the isolation-off no-op
- [x] Existing tests pass locally

## Additional Notes

**Deferred (follow-up, non-blocking):** the revoke-failure audit-log message conflates "not found" with cross-tenant mismatch (internal log only, no caller leak); a pre-existing unused `public` import in `tenant_routes.py`. RLS (#64/#68/#69) remains a separate later effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
