### PR TITLE
Fix HEAD startup crash-loop (shadowed auth_enabled) + MCP served at /mcp not /mcp/mcp

### DIFF
--- a/main.py
+++ b/main.py
@@ -306,8 +306,14 @@ _mcp_server, _mcp_bus = build_mcp_server(
     lambda: app.state.context_engine,
     db_accessor=lambda: app.state.db,
 )
+# Serve the streamable-HTTP endpoint at exactly /mcp. The SDK builds a Starlette
+# Route at streamable_http_path, so graft that route onto the app directly:
+# app.mount("/mcp", ...) would prefix it to /mcp/mcp, and mounting a root-path
+# sub-app 307-redirects /mcp -> /mcp/ (which non-redirect-following MCP clients
+# reject). The session-manager lifecycle is driven explicitly in lifespan
+# (session_manager.run()), so the sub-app is only a source of the route.
 _mcp_starlette_app = _mcp_server.streamable_http_app(streamable_http_path="/mcp")
-app.mount("/mcp", _mcp_starlette_app)
+app.router.routes.extend(_mcp_starlette_app.routes)
 
 # CORS Configuration
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*").split(",") if os.getenv("CORS_ORIGINS") else ["*"]

--- a/main.py
+++ b/main.py
@@ -39,6 +39,29 @@ setup_logging(level=LOG_LEVEL, json_output=LOG_JSON, service_name="contex")
 logger = get_logger(__name__)
 
 
+def run_startup_checks(app: FastAPI) -> None:
+    """Boot-time fail-closed gates, run once during startup.
+
+    Kept out of the lifespan body so it is unit-testable without a live
+    database/Redis: it only inspects routes and reads env/config.
+    """
+    # Fail-closed authz gate: refuse to boot if any route lacks a require()/public decision.
+    assert_authz_coverage(app)
+    logger.info("Authz coverage gate passed")
+
+    # Refuse to bind a non-loopback address when auth is off, unless the
+    # operator explicitly opts out via CONTEX_PROTECTED_MODE=false.
+    check_protected_mode(
+        os.getenv("CONTEX_HOST", "0.0.0.0"),
+        auth_on=auth_enabled(),
+        protected=os.getenv("CONTEX_PROTECTED_MODE", "true").lower() == "true",
+    )
+    logger.info("Protected mode check passed")
+
+    check_hardened_config()
+    logger.info("Hardened-config preflight passed")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for startup and shutdown"""
@@ -225,8 +248,7 @@ async def lifespan(app: FastAPI):
     print("Health: http://localhost:8001/api/health")
     print("Metrics: http://localhost:8001/api/metrics")
 
-    auth_enabled = os.getenv("AUTH_ENABLED", "false").lower() == "true"
-    if auth_enabled:
+    if auth_enabled():
         print("Security: API Key Auth + RBAC + Rate Limiting ENABLED")
     else:
         print("Security: Authentication DISABLED (set AUTH_ENABLED=true for production)")
@@ -238,21 +260,7 @@ async def lifespan(app: FastAPI):
     app.state.redis = redis
     app.state.health_checker = health_checker
 
-    # Fail-closed authz gate: refuse to boot if any route lacks a require()/public decision.
-    assert_authz_coverage(app)
-    logger.info("Authz coverage gate passed")
-
-    # Protected mode: refuse to bind a non-loopback address when auth is off,
-    # unless the operator explicitly opts out via CONTEX_PROTECTED_MODE=false.
-    check_protected_mode(
-        os.getenv("CONTEX_HOST", "0.0.0.0"),
-        auth_on=auth_enabled(),
-        protected=os.getenv("CONTEX_PROTECTED_MODE", "true").lower() == "true",
-    )
-    logger.info("Protected mode check passed")
-
-    check_hardened_config()
-    logger.info("Hardened-config preflight passed")
+    run_startup_checks(app)
 
     # Wire MCP server: store references and enter the session manager context.
     # The MCP server and bus were built at module level with a lazy engine accessor;

--- a/main.py
+++ b/main.py
@@ -306,14 +306,12 @@ _mcp_server, _mcp_bus = build_mcp_server(
     lambda: app.state.context_engine,
     db_accessor=lambda: app.state.db,
 )
-# Serve the streamable-HTTP endpoint at exactly /mcp. The SDK builds a Starlette
-# Route at streamable_http_path, so graft that route onto the app directly:
-# app.mount("/mcp", ...) would prefix it to /mcp/mcp, and mounting a root-path
-# sub-app 307-redirects /mcp -> /mcp/ (which non-redirect-following MCP clients
-# reject). The session-manager lifecycle is driven explicitly in lifespan
-# (session_manager.run()), so the sub-app is only a source of the route.
-_mcp_starlette_app = _mcp_server.streamable_http_app(streamable_http_path="/mcp")
-app.router.routes.extend(_mcp_starlette_app.routes)
+# Mount the MCP streamable-HTTP app under /mcp. The sub-app serves at its own root
+# ("/"), so the endpoint is /mcp — passing streamable_http_path="/mcp" here would
+# compose with the mount prefix to /mcp/mcp. Starlette 307-redirects /mcp -> /mcp/,
+# which MCP clients follow. The session-manager lifecycle is run in lifespan.
+_mcp_starlette_app = _mcp_server.streamable_http_app(streamable_http_path="/")
+app.mount("/mcp", _mcp_starlette_app)
 
 # CORS Configuration
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*").split(",") if os.getenv("CORS_ORIGINS") else ["*"]

--- a/src/core/authz_coverage.py
+++ b/src/core/authz_coverage.py
@@ -6,12 +6,10 @@ from starlette.routing import Mount, Route, WebSocketRoute
 
 from src.core.authz import require, public
 
-ALLOWED_MOUNTS = {"/static"}
+# /mcp is the MCP streamable endpoint (self-authenticates via the SDK TokenVerifier,
+# per-tool default-deny); /static is framework assets.
+ALLOWED_MOUNTS = {"/mcp", "/static"}
 PUBLIC_FRAMEWORK_PATHS = {"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
-# Bare Starlette routes that enforce their own auth. The MCP streamable endpoint
-# is grafted onto the app as a Route (not a Mount) and self-authenticates via the
-# SDK TokenVerifier (per-tool default-deny).
-SELF_AUTH_ROUTES = {"/mcp"}
 
 
 def _dependant_is_marked(dependant) -> bool:
@@ -44,13 +42,8 @@ def find_uncovered_routes(app) -> list[str]:
             # No HTTP dependant; require explicit allowlisting when one is added.
             uncovered.append(f"WEBSOCKET {route.path} (websocket routes need explicit review)")
             continue
-        # Bare Starlette Route (e.g. framework health, MCP) — allow only if in the
-        # public set or the self-authenticating set.
-        if (
-            isinstance(route, Route)
-            and route.path not in PUBLIC_FRAMEWORK_PATHS
-            and route.path not in SELF_AUTH_ROUTES
-        ):
+        # Bare Starlette Route (e.g. framework health) — allow only if in the public set.
+        if isinstance(route, Route) and route.path not in PUBLIC_FRAMEWORK_PATHS:
             # FastAPI mounts most things as APIRoute; a bare Route is unusual → flag it.
             uncovered.append(f"ROUTE {route.path} (unexpected bare route)")
     return uncovered

--- a/src/core/authz_coverage.py
+++ b/src/core/authz_coverage.py
@@ -6,8 +6,12 @@ from starlette.routing import Mount, Route, WebSocketRoute
 
 from src.core.authz import require, public
 
-ALLOWED_MOUNTS = {"/mcp", "/static"}
+ALLOWED_MOUNTS = {"/static"}
 PUBLIC_FRAMEWORK_PATHS = {"/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"}
+# Bare Starlette routes that enforce their own auth. The MCP streamable endpoint
+# is grafted onto the app as a Route (not a Mount) and self-authenticates via the
+# SDK TokenVerifier (per-tool default-deny).
+SELF_AUTH_ROUTES = {"/mcp"}
 
 
 def _dependant_is_marked(dependant) -> bool:
@@ -40,8 +44,13 @@ def find_uncovered_routes(app) -> list[str]:
             # No HTTP dependant; require explicit allowlisting when one is added.
             uncovered.append(f"WEBSOCKET {route.path} (websocket routes need explicit review)")
             continue
-        # Bare Starlette Route (e.g. framework health) — allow only if in the public set.
-        if isinstance(route, Route) and route.path not in PUBLIC_FRAMEWORK_PATHS:
+        # Bare Starlette Route (e.g. framework health, MCP) — allow only if in the
+        # public set or the self-authenticating set.
+        if (
+            isinstance(route, Route)
+            and route.path not in PUBLIC_FRAMEWORK_PATHS
+            and route.path not in SELF_AUTH_ROUTES
+        ):
             # FastAPI mounts most things as APIRoute; a bare Route is unusual → flag it.
             uncovered.append(f"ROUTE {route.path} (unexpected bare route)")
     return uncovered

--- a/tests/test_mcp_mount.py
+++ b/tests/test_mcp_mount.py
@@ -1,5 +1,3 @@
-from starlette.routing import Match
-
 import main
 
 
@@ -8,16 +6,12 @@ def test_mcp_mounted_at_slash_mcp():
     assert any(p == "/mcp" or p.startswith("/mcp") for p in paths), f"/mcp not mounted; routes={paths}"
 
 
-def _matches(path: str) -> bool:
-    scope = {"type": "http", "path": path, "method": "POST", "headers": []}
-    return any(r.matches(scope)[0] == Match.FULL for r in main.app.routes)
-
-
-def test_mcp_endpoint_is_exactly_slash_mcp_not_doubled():
-    # The endpoint must resolve at exactly /mcp — not /mcp/mcp (the bug from
-    # mounting a /mcp-path sub-app under a /mcp prefix).
-    assert _matches("/mcp"), "no route matches /mcp"
-    assert not _matches("/mcp/mcp"), "/mcp/mcp still resolves — path is doubled"
+def test_mcp_mount_prefix_is_exactly_slash_mcp():
+    # The mount prefix must be /mcp, not /mcp/mcp — the sub-app is built with
+    # streamable_http_path="/" so it does not re-add the prefix.
+    paths = [getattr(r, "path", "") for r in main.app.routes]
+    assert "/mcp" in paths, f"no /mcp mount; routes={paths}"
+    assert "/mcp/mcp" not in paths, "MCP path is doubled to /mcp/mcp"
 
 
 def test_build_mcp_server_is_wired_in_main():

--- a/tests/test_mcp_mount.py
+++ b/tests/test_mcp_mount.py
@@ -1,9 +1,23 @@
+from starlette.routing import Match
+
 import main
 
 
 def test_mcp_mounted_at_slash_mcp():
     paths = [getattr(r, "path", "") for r in main.app.routes]
     assert any(p == "/mcp" or p.startswith("/mcp") for p in paths), f"/mcp not mounted; routes={paths}"
+
+
+def _matches(path: str) -> bool:
+    scope = {"type": "http", "path": path, "method": "POST", "headers": []}
+    return any(r.matches(scope)[0] == Match.FULL for r in main.app.routes)
+
+
+def test_mcp_endpoint_is_exactly_slash_mcp_not_doubled():
+    # The endpoint must resolve at exactly /mcp — not /mcp/mcp (the bug from
+    # mounting a /mcp-path sub-app under a /mcp prefix).
+    assert _matches("/mcp"), "no route matches /mcp"
+    assert not _matches("/mcp/mcp"), "/mcp/mcp still resolves — path is doubled"
 
 
 def test_build_mcp_server_is_wired_in_main():

--- a/tests/test_startup_checks.py
+++ b/tests/test_startup_checks.py
@@ -1,0 +1,25 @@
+"""Regression tests for the boot-time startup checks.
+
+These guard the lifespan startup path, which no test previously exercised — a
+shadowed `auth_enabled` (a bool local calling the function) crash-looped the
+server on real startup while every ASGITransport test (which skips the lifespan)
+stayed green.
+"""
+import pytest
+
+import main
+
+
+def test_startup_checks_pass_when_auth_off_on_loopback(monkeypatch):
+    # Regression: this calls auth_enabled() — a shadowing bool local would raise
+    # "'bool' object is not callable" here.
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("CONTEX_HOST", "127.0.0.1")
+    main.run_startup_checks(main.app)
+
+
+def test_startup_checks_fail_closed_when_auth_on_without_jwt_secret(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.delenv("SERVICE_ACCOUNT_JWT_SECRET", raising=False)
+    with pytest.raises(RuntimeError, match="SERVICE_ACCOUNT_JWT_SECRET"):
+        main.run_startup_checks(main.app)


### PR DESCRIPTION
## Description

Two startup/serving bugs live on `main` (HEAD), fixed as two single-purpose commits.

### 1. `fix(startup)` — crash-loop on boot (shadowed `auth_enabled`)
Inside `lifespan`, a local `auth_enabled = os.getenv("AUTH_ENABLED", ...)` bool **shadowed** the imported `auth_enabled` function, so the subsequent `auth_enabled()` call in the protected-mode check raised `TypeError: 'bool' object is not callable` — crash-looping the server on every real startup. It was invisible to the test suite because the `httpx.ASGITransport` tests deliberately skip the lifespan, so **no test ever exercised the startup path**.

Fix: drop the shadowing local (the banner now calls `auth_enabled()` directly) and extract the three boot gates into a module-level `run_startup_checks(app)` so the path is unit-testable without a live DB/Redis. Added `tests/test_startup_checks.py` (auth-off/loopback boots; auth-on without `SERVICE_ACCOUNT_JWT_SECRET` fails closed) — this is the regression guard the suite was missing.

### 2. `fix(mcp)` — endpoint served at `/mcp/mcp` instead of `/mcp`
`streamable_http_app(streamable_http_path="/mcp")` mounted at `/mcp` composed to `/mcp/mcp`. Mounting a root-path (`/`) sub-app instead would serve `/mcp/` and **307-redirect** `/mcp` → `/mcp/`, which MCP clients that don't follow redirects (httpx defaults to not following) reject. So instead I graft the SDK's `Route` onto the app directly, giving exactly `/mcp` with no redirect and no doubling. The session manager is already run explicitly in `lifespan`, so the sub-app was only ever a route source (a mounted sub-app's lifespan isn't run by the parent anyway).

`/mcp` is now a bare `Route` rather than a `Mount`, so the authz coverage gate is updated to allow it as a self-authenticating route — MCP enforces its own per-tool auth via the SDK `TokenVerifier`, the same posture the `/mcp` mount allowlist already granted.

## Type of Change
- [x] Bug fix (crash-loop; wrong MCP path)

## Testing
- New/updated: `tests/test_startup_checks.py`, `tests/test_mcp_mount.py` (asserts `/mcp` resolves and `/mcp/mcp` does not). Targeted sweep (startup, mcp mount/adapter/auth, authz matrix, security): **32 passed**.
- **Real `uvicorn` boot** (the crash only manifests on real startup): `Application startup complete`, no traceback; `POST /mcp` → 400 (reaches the MCP handler — a bare POST isn't a valid handshake), `POST /mcp/mcp` → 404 (doubling gone).
- Full suite not attached here — it currently carries pre-existing order-dependent pollution (#134); the affected surface is covered by the targeted sweep + the live boot.

## Notes
No new migration. No behavior change for correctly-configured deployments beyond fixing the crash and the endpoint path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
