### PR TITLE
chore(deps): upgrade all dependencies to latest stable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,47 +1,47 @@
 # Core dependencies
-mcp==2.0.0
-pydantic==2.13.4
+mcp==2.2.0
+pydantic==2.13.5
 fastapi==0.141.1
-uvicorn[standard]==0.52.3
-httpx==0.27.2
-jinja2==3.1.2
-aiofiles==23.2.1
-python-multipart==0.0.20
-prometheus-client==0.19.0
+uvicorn[standard]==0.52.4
+httpx==0.28.1
+jinja2==3.1.6
+aiofiles==25.1.0
+python-multipart==0.0.32
+prometheus-client==0.26.0
 
 # Database (PostgreSQL)
-asyncpg==0.29.0
-sqlalchemy[asyncio]==2.0.25
-pgvector==0.2.4
-alembic==1.13.1
-greenlet==3.0.3
+asyncpg==0.31.0
+sqlalchemy[asyncio]==2.0.52
+pgvector==0.5.0
+alembic==1.20.0
+greenlet==3.5.5
 
 # Redis (for pub/sub only)
-redis==7.1.0
+redis==8.1.0
 
 # Embedding model for semantic matching
-sentence-transformers==3.3.1
-scikit-learn==1.7.2
+sentence-transformers==6.0.1
+scikit-learn==1.9.1
 
 # Numerical operations for embeddings / rank fusion
-numpy==2.3.5
+numpy==2.5.3
 
 # Document parsing (PDF, DOCX)
-pymupdf==1.25.3
-python-docx==1.1.2
+pymupdf==1.28.2
+python-docx==1.2.0
 
 # Utilities
-python-dotenv==1.0.0
-tiktoken==0.5.2
-toon-format @ git+https://github.com/toon-format/toon-python.git
-pyyaml==6.0.1
+python-dotenv==1.2.3
+tiktoken==0.14.0
+toon-format==0.1.0
+pyyaml==6.0.3
 toml==0.10.2
 
 # Authentication (JWT for service accounts)
-PyJWT==2.13.0
+PyJWT==2.14.0
 
 # Error tracking
-sentry-sdk[fastapi]==2.68.0
+sentry-sdk[fastapi]==2.69.1
 
 # Distributed Tracing (OpenTelemetry)
 opentelemetry-api==1.44.0
@@ -51,8 +51,8 @@ opentelemetry-instrumentation-redis==0.65b0
 opentelemetry-exporter-otlp==1.44.0
 
 # Testing
-pytest==9.0.1
-pytest-asyncio==1.3.0
-pytest-mock==3.12.0
-fakeredis==2.32.0
-aiosqlite==0.19.0
+pytest==9.1.1
+pytest-asyncio==1.4.0
+pytest-mock==3.15.1
+fakeredis==2.38.0
+aiosqlite==0.22.1

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -1,4 +1,5 @@
 # tests/test_authz.py
+import httpx
 import pytest
 from fastapi import Depends, FastAPI
 from httpx import AsyncClient
@@ -34,14 +35,14 @@ def test_require_and_public_contract():
 @pytest.mark.asyncio
 async def test_auth_off_allows_everything(monkeypatch):
     monkeypatch.setattr(authz, "auth_enabled", lambda: False)
-    async with AsyncClient(app=_build_app(), base_url="http://t") as c:
+    async with AsyncClient(transport=httpx.ASGITransport(app=_build_app()), base_url="http://t") as c:
         assert (await c.get("/publish")).status_code == 200  # no key needed when off
 
 
 @pytest.mark.asyncio
 async def test_auth_on_missing_key_401(monkeypatch):
     monkeypatch.setattr(authz, "auth_enabled", lambda: True)
-    async with AsyncClient(app=_build_app(), base_url="http://t") as c:
+    async with AsyncClient(transport=httpx.ASGITransport(app=_build_app()), base_url="http://t") as c:
         assert (await c.get("/publish")).status_code == 401
         assert (await c.get("/open")).status_code == 200  # public bypasses
 
@@ -53,5 +54,5 @@ async def test_auth_on_insufficient_scope_403(monkeypatch):
                         tenant_id=None, projects=(), role=None)
     app = _build_app()
     app.dependency_overrides[get_identity] = lambda: readonly
-    async with AsyncClient(app=app, base_url="http://t") as c:
+    async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as c:
         assert (await c.get("/publish")).status_code == 403

--- a/tests/test_publish_route_provenance.py
+++ b/tests/test_publish_route_provenance.py
@@ -4,6 +4,7 @@ Test: HTTP publish route stamps server-attested provenance (source/actor/tenant_
 TDD: this test must FAIL before the route wiring (Task 4) and PASS after.
 """
 
+import httpx
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import FastAPI, Request
@@ -43,7 +44,7 @@ async def test_publish_route_stamps_provenance():
         patch("src.core.metrics.record_event_published", new=MagicMock()),
         patch("src.core.metrics.publish_duration_seconds", new=chainable_hist),
     ):
-        async with AsyncClient(app=app, base_url="http://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
                 "/api/v1/data/publish",
                 json={"project_id": "route-prov", "data_key": "k", "data": {"x": 1}},

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,5 +1,6 @@
 """Tests for rate limiting with PostgreSQL"""
 
+import httpx
 import pytest
 import pytest_asyncio
 import time
@@ -134,7 +135,7 @@ class TestRateLimitMiddleware:
     @pytest.mark.asyncio
     async def test_middleware_allows_within_limit(self, app_with_rate_limit):
         """Test that middleware allows requests within limit"""
-        async with AsyncClient(app=app_with_rate_limit, base_url="http://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app_with_rate_limit), base_url="http://test") as client:
             # Make several requests (should all succeed)
             for i in range(5):
                 response = await client.get(
@@ -167,7 +168,7 @@ class TestRateLimitMiddleware:
     @pytest.mark.asyncio
     async def test_middleware_skips_health_checks(self, app_with_rate_limit):
         """Test that middleware skips rate limiting for health checks"""
-        async with AsyncClient(app=app_with_rate_limit, base_url="http://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app_with_rate_limit), base_url="http://test") as client:
             # Make many health check requests (should never be rate limited)
             for i in range(100):
                 response = await client.get("/health")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,5 +1,6 @@
 """Tests for security features"""
 
+import httpx
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
@@ -43,7 +44,7 @@ class TestSecurityHeaders:
     @pytest.mark.asyncio
     async def test_security_headers_present(self, app_with_security_headers):
         """Test that security headers are added to responses"""
-        async with AsyncClient(app=app_with_security_headers, base_url="http://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app_with_security_headers), base_url="http://test") as client:
             response = await client.get("/test")
 
             assert response.status_code == 200
@@ -69,7 +70,7 @@ class TestSecurityHeaders:
     @pytest.mark.asyncio
     async def test_hsts_only_on_https(self, app_with_security_headers):
         """Test that HSTS is only added for HTTPS requests"""
-        async with AsyncClient(app=app_with_security_headers, base_url="http://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app_with_security_headers), base_url="http://test") as client:
             response = await client.get("/test")
 
             # HTTP request should not have HSTS header
@@ -85,7 +86,7 @@ class TestSecurityHeaders:
         async def test_endpoint():
             return {"status": "ok"}
 
-        async with AsyncClient(app=app, base_url="https://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="https://test") as client:
             response = await client.get("/test")
 
             # HTTPS request should have HSTS header
@@ -103,7 +104,7 @@ class TestSecurityHeaders:
         async def test_endpoint():
             return {"status": "ok"}
 
-        async with AsyncClient(app=app, base_url="https://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="https://test") as client:
             response = await client.get("/test")
 
             # Even for HTTPS, HSTS should not be present when disabled
@@ -112,7 +113,7 @@ class TestSecurityHeaders:
     @pytest.mark.asyncio
     async def test_csp_frame_ancestors_none(self, app_with_security_headers):
         """Test that CSP includes frame-ancestors 'none'"""
-        async with AsyncClient(app=app_with_security_headers, base_url="http://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app_with_security_headers), base_url="http://test") as client:
             response = await client.get("/test")
 
             csp = response.headers.get("Content-Security-Policy", "")

--- a/tests/test_tenant.py
+++ b/tests/test_tenant.py
@@ -1,5 +1,6 @@
 """Tests for Multi-Tenant Management with PostgreSQL"""
 
+import httpx
 import pytest
 import pytest_asyncio
 
@@ -627,7 +628,7 @@ class TestTenantMiddlewareIdentityDerivation:
         from httpx import AsyncClient
 
         app, raw_key = app_and_key
-        async with AsyncClient(app=app, base_url="http://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.get(
                 "/whoami",
                 headers={"X-API-Key": raw_key, "X-Tenant-ID": "tenant-b"},
@@ -639,7 +640,7 @@ class TestTenantMiddlewareIdentityDerivation:
         from httpx import AsyncClient
 
         app, raw_key = app_and_key
-        async with AsyncClient(app=app, base_url="http://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.get(
                 "/whoami",
                 headers={"X-API-Key": raw_key, "X-Tenant-ID": "tenant-a"},
@@ -652,7 +653,7 @@ class TestTenantMiddlewareIdentityDerivation:
         from httpx import AsyncClient
 
         app, raw_key = app_and_key
-        async with AsyncClient(app=app, base_url="http://test") as client:
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.get("/whoami", headers={"X-API-Key": raw_key})
         assert resp.status_code == 200
         assert resp.json()["tenant_id"] == "tenant-a"

--- a/tests/test_version_routes.py
+++ b/tests/test_version_routes.py
@@ -8,6 +8,7 @@ real ContextEngine backed by the live Postgres event store and assert they
 return 200 for a normal case.
 """
 
+import httpx
 import numpy as np
 import pytest
 import pytest_asyncio
@@ -41,7 +42,7 @@ async def client(engine):
     app = FastAPI()
     app.include_router(version_router)
     app.state.context_engine = engine
-    async with AsyncClient(app=app, base_url="http://test") as c:
+    async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as c:
         yield c
 
 


### PR DESCRIPTION
## Description

Swept `requirements.txt` to the latest stable release of every package on PyPI, **including the majors** (approved). Two commits: the httpx test-transport migration first (forward-compatible with the old httpx), then the version bump — so each is independently green.

### Notable upgrades
- **Majors:** redis 7→8, sentence-transformers 3→6 (model stays `all-MiniLM-L6-v2`, embeddings still **384-dim**), pgvector 0.2→0.5, aiofiles 23→25, httpx 0.27→0.28.
- **Minor/patch:** mcp 2.0→2.2, numpy 2.5.3, sqlalchemy 2.0.52, alembic 1.20, scikit-learn 1.9.1, tiktoken 0.14, pydantic 2.13.5, asyncpg 0.31, greenlet 3.5.5, PyJWT 2.14, sentry-sdk 2.69.1, pymupdf 1.28.2, python-docx 1.2, python-dotenv 1.2.3, prometheus-client 0.26, pyyaml 6.0.3, python-multipart 0.0.32, uvicorn 0.52.4, jinja2 3.1.6, and the test stack (pytest 9.1.1, pytest-asyncio 1.4, pytest-mock 3.15.1, fakeredis 2.38, aiosqlite 0.22.1).
- **`toon-format`** switched from a git-tracking dependency to the published `==0.1.0` (reproducible pin).
- Already latest, unchanged: fastapi 0.141.1, OpenTelemetry api/sdk/exporter 1.44.0 and instrumentation 0.65b0 (the `bXX` suffix is normal for OTel instrumentation).

### httpx 0.28
0.28 removes the deprecated `AsyncClient(app=...)` shortcut. Migrated all 15 call-sites across 6 test files to the supported `ASGITransport(app=...)` form (commit 1).

## Testing
- **Full suite: 490 passed, 0 failed.**
- Runtime-verified the risky majors directly: `redis` 8 ping, sentence-transformers 6 `encode()` → 384-dim, `pgvector.sqlalchemy.Vector` import, `build_mcp_server()` (mcp 2.2), tiktoken 0.14, `import main`.
- Resolution is clean (dry-run + install); the two pip warnings about `prometheus-fastapi-instrumentator`/`coremltools` are pre-existing env cruft — neither is a project dependency.

## Out of scope (as agreed)
Container images left untouched: `python:3.11-slim`, `pgvector/pgvector:pg16`, `redis:7-alpine`. Bumping the Postgres/runtime images (especially the DB major) warrants a separate, deliberate pass. The `sdk/python` package keeps its permissive `>=` ranges (correct for a published library — they already allow the latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)